### PR TITLE
spec/Vehicle: Add AccessoryOn signal

### DIFF
--- a/spec/Vehicle/Vehicle.vspec
+++ b/spec/Vehicle/Vehicle.vspec
@@ -162,6 +162,11 @@ IgnitionOffTime:
   unit: s
   description: Accumulated ignition off time in seconds.
 
+AccessoryOn:
+  datatype: boolean
+  type: sensor
+  description: Indicates whether the vehicle accessory is on or off.
+
 DriveTime:
   datatype: uint32
   type: sensor


### PR DESCRIPTION
I could not find Accessory (ACC) signal in the VSS.

ACC is a common signal that is turned on before Ingnition.

https://cars-care.net/what-is-acc-in-a-car/
https://mservice411.com/c/ignition-switch

I propose adding an `AccessoryON` because some car have separate Ignition and Accessory signals in CAN.
And the signals are often next to each other in CAN.