### PR TITLE
Changing type of Charging.TimeToComplete

### DIFF
--- a/spec/Powertrain/Battery.vspec
+++ b/spec/Powertrain/Battery.vspec
@@ -159,7 +159,7 @@ Charging.ChargeRate:
   description: Current charging rate, as in kilometers of range added per hour.
 
 Charging.TimeToComplete:
-  datatype: uint32
+  datatype: int32
   type: sensor
   unit: s
   description: The time needed to complete the current charging process to the set charge limit. 0 if charging is complete, negative number if no charging process is active.


### PR DESCRIPTION
The description states that negative numbers can be used to indicate that
no charging process is active, and to use that a signed datatype is needed