### PR TITLE
Renaming Battery-branch to TractionBattery

### DIFF
--- a/spec/VehicleSignalSpecification.vspec
+++ b/spec/VehicleSignalSpecification.vspec
@@ -99,15 +99,16 @@ Vehicle.Powertrain.ElectricMotor:
 
 
 #
-# The battery signals and attributes used to host the signals in Battery.vspec.
+# The traction battery branch refers to signals and attributes related to the battery used by electrical
+# and hybrid vehicles for the electric motor.
+# It does not refer to signals and attributes related to the supply voltage battery used by
+# traditional vehicles with combustion engine
 #
-Vehicle.Powertrain.Battery:
+Vehicle.Powertrain.TractionBattery:
   type: branch
   description: Battery Management data.
 
-# Include the battery management vspec file and attach all its signals and attributes under the
-# battery management branch created above.
-#include Powertrain/Battery.vspec Vehicle.Powertrain.Battery
+#include Powertrain/Battery.vspec Vehicle.Powertrain.TractionBattery
 
 
 #


### PR DESCRIPTION
A vehicle might have several battery systems, including the traditional
supply voltage battery (typically 12 Volts for passenger cars) and if
the vehicle has an electrical powertrain also a high voltage battery.

The current Battery-branch contains today signals only related
to the high voltage battery, but that is not obvious from the branch name.
To avoid this ambiguity we suggest renaming the branch to HighVoltageBattery.

Example with new naming:

`"Vehicle.Powertrain.HighVoltageBattery.NominalVoltage"`

Example with old naming:

`"Vehicle.Powertrain.Battery.NominalVoltage"`