### PR TITLE
Removing byteBuffer

### DIFF
--- a/docs-gen/content/rule_set/data_entry/data_types.md
+++ b/docs-gen/content/rule_set/data_entry/data_types.md
@@ -22,8 +22,6 @@ boolean    | boolean value              | 0/false | 1/true
 float      | floating point number      | -3.4e -38 | 3.4e 38
 double     | double precision floating point number | -1.7e -300 | 1.7e 300
 string     | character string           | n/a  | n/a
-byteBuffer | buffer of bytes (aka BLOB) | n/a | n/a
-
 
 ## Arrays
 


### PR DESCRIPTION
Considered to be a duplicate of uint8[]
Has previously not been supported by tooling so removing
it from documentation shall not cause any backwards compatibility issues.

See https://github.com/GENIVI/vss-tools/issues/102
and https://github.com/GENIVI/vss-tools/pull/103