### PR TITLE
README.md: Change GENIVI to COVESA

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,40 +2,40 @@
 
 
 [![License](https://img.shields.io/badge/License-MPL%202.0-blue.svg)](https://opensource.org/licenses/MPL-2.0)
-[![Build Status](https://github.com/GENIVI/vehicle_signal_specification/actions/workflows/buildcheck.yml/badge.svg)](https://github.com/GENIVI/vehicle_signal_specification/actions/workflows/buildcheck.yml?query=branch%3Amaster)
+[![Build Status](https://github.com/COVESA/vehicle_signal_specification/actions/workflows/buildcheck.yml/badge.svg)](https://github.com/COVESA/vehicle_signal_specification/actions/workflows/buildcheck.yml?query=branch%3Amaster)
 
 The overall goal of the Vehicle Signal Specification (VSS)  is to create a common understanding of vehicle signals in order to reach a “common language” independent of the protocol or serialisation format. 
 
-Please find the official documentation at: [Vehicle Signal Specification](https://genivi.github.io/vehicle_signal_specification/)
+Please find the official documentation at: [Vehicle Signal Specification](https://covesa.github.io/vehicle_signal_specification/)
 
 ## Getting started
 
 ### Using VSS
-To use a specific version of VSS in your toolchain, head over to our [releases page](https://genivi.github.io/vehicle_signal_specification/releases/).
+To use a specific version of VSS in your toolchain, head over to our [releases page](https://github.com/COVESA/vehicle_signal_specification/releases/).
 
 
-**Latest release:** [2.1](https://github.com/GENIVI/vehicle_signal_specification/releases/tag/v2.1)
+**Latest release:** [2.1](https://github.com/COVESA/vehicle_signal_specification/releases/tag/v2.1)
 
 ### Discuss all things VSS, "meet" the community
-The community has regular calls to discuss topics around VSS. This includes specific tickets in this repository as well as the broader direction in which VSS is evolving.  You can find current call coordinates and dates in [our wiki](https://github.com/GENIVI/vehicle_signal_specification/wiki/Weekly-meeting#meeting). 
+The community has regular calls to discuss topics around VSS. This includes specific tickets in this repository as well as the broader direction in which VSS is evolving.  You can find current call coordinates and dates in [our wiki](https://github.com/COVESA/vehicle_signal_specification/wiki/Weekly-meeting#meeting). 
 
 
 ### Contribute to VSS
-Work towards version 2.2 is continuously ongoing in the [master branch](https://github.com/GENIVI/vehicle_signal_specification/tree/master)
+Work towards version 2.2 is continuously ongoing in the [master branch](https://github.com/COVESA/vehicle_signal_specification/tree/master)
 
 To work with the specification directly, you need to clone this repository.
 
 This repository uses git submodules.  Please make sure you clone recursively,
 
 ```
-git clone --recurse-submodules https://github.com/GENIVI/vehicle_signal_specification
+git clone --recurse-submodules https://github.com/COVESA/vehicle_signal_specification
 ```
 
 
 Alternatively, just init and update the submodules after the initial cloning:
 
 ```
-git clone https://github.com/GENIVI/vehicle_signal_specification
+git clone https://github.com/COVESA/vehicle_signal_specification
 git submodule update --init
 ```
 

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -7,8 +7,8 @@ provisions of the license provided by the LICENSE file in this repository.
 This document describes the process for creating a new version of the
 signal specification.
 
-The process, driven by GENIVI with significant input from the W3C Automotive WG, is aimed at being lightweight and carried
-out in public, giving both GENIVI members and non-members a say in the
+The process, driven by COVESA with significant input from the W3C Automotive WG, is aimed at being lightweight and carried
+out in public, giving both COVESA members and non-members a say in the
 creation of a new version.
 
 ![Release Process](pics/vss_release_process.png)


### PR DESCRIPTION
The link to the documentation in the Readme gave a 404 as the genivi subdomain for github pages has been deleted. This PR fixes that. Also replaced other occurences of Genivi with COVESA