### PR TITLE
Vehicle.vspec: add missing version attribute values

### DIFF
--- a/spec/Vehicle/Vehicle.vspec
+++ b/spec/Vehicle/Vehicle.vspec
@@ -22,16 +22,19 @@ VersionVSS:
 VersionVSS.Major:
   datatype: uint32
   type: attribute
+  default: 2
   description: Supported Version of VSS - Major version
 
 VersionVSS.Minor:
   datatype: uint32
   type: attribute
+  default: 1
   description: Supported Version of VSS - Minor version
 
 VersionVSS.Patch:
   datatype: uint32
   type: attribute
+  default: 0
   description: Supported Version of VSS - Patch version
 
 VersionVSS.Label:


### PR DESCRIPTION
Currently no values are set for the VSS Major, Minor and Patch
attributes in the Vehicle.vspec that communicate the VSS version.
Address this by setting a default value for each attribute starting
with the last released version 2.1.0.

Possible solution to issue #343 