### PR TITLE
Proposed documentation of "description" and "comment"

### DIFF
--- a/docs-gen/content/rule_set/branches.md
+++ b/docs-gen/content/rule_set/branches.md
@@ -28,8 +28,14 @@ The value ```branch``` specifies that this is a branch entry (as
 opposed to a signal entry). This is the default, in case ```type``` is omitted.
 
 **```description```**  
-A description string to be included (when applicable) in the various
-specification files generated from this branch entry.
+Describes the meaning and content of the branch.
+Recommended to start with a capital letter and end with a dot (`.`).
+
+**```comment ```**  *[optional]* `since version 3.0`
+A comment can be used to provide additional informal information on a branch.
+This could include background information on the rationale for the branch,
+references to related branches, standards and similar.
+Recommended to start with a capital letter and end with a dot (`.`).
 
 **```aggregate```** *[optional]*  
 Defines whether or not this branch is an aggregate.

--- a/docs-gen/content/rule_set/data_entry/sensor_actuator.md
+++ b/docs-gen/content/rule_set/data_entry/sensor_actuator.md
@@ -9,8 +9,9 @@ entry example is given below:
 ```YAML
 Speed:
   type: sensor
-  description: The vehicle speed, as measured by the drivetrain.
-  datatype: uint16
+  description: The vehicle speed.
+  comment: For engine speed see Vehicle.Powertrain.CombustionEngine.Engine.Speed.
+  datatype: float
   unit: km/h
   min: 0
   max: 300
@@ -24,13 +25,21 @@ all parental branches included in the name must be defined as well.
 Defines the type of the node. This can be ```branch```,
 ```sensor```, ```actuator```, ```stream``` or attribute.
 
-**```description```**  
-A description string to be included (when applicable) in the various
-specification files generated from this data entry.
-
 **```datatype```**  
 The string value of the type specifies the scalar type of the data entry
 value. See [data type](#data-type) chapter for a list of available types.
+
+**```description```**  
+Describes the meaning and content of the signal.
+The `description`shall together with other mandatory members like `datatype` and `unit` provide sufficient information
+to understand what the signal contains and how signal values shall be constructed or interpreted.
+Recommended to start with a capital letter and end with a dot (`.`).
+
+**```comment ```**  *[optional]* `since version 3.0`
+A comment can be used to provide additional informal information on a signal.
+This could include background information on the rationale for the signal design,
+references to related signals, standards and similar.
+Recommended to start with a capital letter and end with a dot (`.`).
 
 **```min```** *[optional]*  
 The minimum value, within the interval of the given ```type```, that the


### PR DESCRIPTION

In last VSS meeting we discussed #364. There seems to be an agreement that `comment`could be useful, but it must be clear that all information required to understand a signal or to send a signal with the correct value must be present in description together with other. I tried to document this. I also tried to add some style-guidelines, think that would be good to have.

If we take the `DistractionLevel` signal as an example, then maybe something like below could fulfill our requirements on how `description` and `comments` shall be used. This is a typical case where description is important as there is to my knowledge no standard on how to measure distraction. I assume 100 means that the driver is unconscious, dead or absent and does not react to anything. A sleeping driver is possibly not 100% distracted as the driver might wake up on strong noise.  But shall it be up to the OEM to decide if a driver that has been sleeping for 5 minutes shall be considered to be 95 or 99 percent distracted?

Comments appreaciated. And this PR shall not be merged until we have added basic support for comments in tooling.

```
DistractionLevel:
  datatype: float
  type: sensor
  unit: percent
  min: 0
  max: 100
  description: Distraction level of the driver. 0 = Fully Concentrated on Driving, 100 = Unconscious.  Exact meaning of intermediate values not standardized.
  comment: Can be deduced by multiple factors. E.g. Driving situation, acustical or optical signals inside the cockpit, phone calls.
```


 