### PR TITLE
Improving documentation

### DIFF
--- a/docs-gen/content/rule_set/basics.md
+++ b/docs-gen/content/rule_set/basics.md
@@ -56,7 +56,7 @@ The exact use of ```PosX``` elements and how they correlate to actual
 positions in the car, is dependent on the actual vehicle using the
 spec.
 
-## PARENT NODES
+## Parent Nodes
 If a new leaf node is defined, all parent branches included in its name must
 be included as well, as shown below:
 
@@ -72,7 +72,19 @@ The branches do not have to be defined in any specific order as long
 as each branch component is defined somewhere in the vspec file (or an
 included vspec file).
 
-## DEPRECATION `since version 2.1`
+## Naming Conventions
+
+The recommended naming convention for node elements is to use camel case notation starting with a capital letter. It is recommended to use only
+`A-Z`, `a-z` and `0-9` in node names. For boolean signals it is recommended to start the name with `Is`.
+
+Examples:
+
+```
+SomeBranch.AnotherBranch.MySignalName
+Cabin.Door.Row1.Left.IsLocked
+```
+
+## Deprecation `since version 2.1`
 
 During the process of model development, nodes might be
 moved or deleted. Giving developers a chance to adopt to the

--- a/docs-gen/content/rule_set/data_entry/_index.md
+++ b/docs-gen/content/rule_set/data_entry/_index.md
@@ -7,15 +7,9 @@ weight: 2
 
 # Data Entry
 Leaf nodes of the tree contain metadata describing the data associated to the node.
-In order to help application developers, who are using the specification, it makes a distinction between signals - in the following as [```sensor```](/vehicle_signal_specification/rule_set/data_entry/sensor_actuator), [```actuator```](/vehicle_signal_specification/rule_set/data_entry/sensor_actuator) and [```stream```](/vehicle_signal_specification/rule_set/data_entry/data_types/#data-streams) - and [```attribute```](/vehicle_signal_specification/rule_set/data_entry/attributes).
+In order to help application developers, who are using the specification, it makes a distinction between signals - in the following as [```sensor```](/vehicle_signal_specification/rule_set/data_entry/sensor_actuator) and [```actuator```](/vehicle_signal_specification/rule_set/data_entry/sensor_actuator) - and [```attribute```](/vehicle_signal_specification/rule_set/data_entry/attributes).
 The difference between a signal and an attribute is that the signal has
 a publisher (or producer) that continuously updates the signal value while an
-attribute has a set value, defined in the specification, that never changes.
-As summary, besides [```branch```](/vehicle_signal_specification/rule_set/branches) type can be:
+attribute has a set value that should typically not change more than once per ignition cycle.
 
-* **```attribute```**: attributes are not expected to change once they're set (e.g. vehicle identification number)
-* **```sensor```**: sensor values describe the current state of the vehicle and change over time, as the state of the vehicle changes (e.g. odometer).
-* **```actuator```**: actuating signals describe current state of the vehicle and change, when the state of the vehicle changes. Writing the value, leads to a change of the vehicle state itself (e.g. door lock).
-* **```stream```**, data stream like video.
-
-Examples you'll find in the [sensor and actuator chapter](/vehicle_signal_specification/rule_set/data_entry/sensor_actuator).
+Examples and more information you'll find in the [Sensors & Actuators chapter](/vehicle_signal_specification/rule_set/data_entry/sensor_actuator) and [Attributes chapter](/vehicle_signal_specification/rule_set/data_entry/attributes).

--- a/docs-gen/content/rule_set/data_entry/attributes.md
+++ b/docs-gen/content/rule_set/data_entry/attributes.md
@@ -4,7 +4,7 @@ date: 2019-08-04T12:37:31+02:00
 weight: 4
 ---
 
-An attribute is a signal with a default value, specified by
+An attribute is an entity that has a  default value, specified by
 its ```default``` member.
 The standard Vehicle Signal Specification include default values for most attributes. 
 It is expected that these default values do not fit all values.

--- a/docs-gen/content/rule_set/data_entry/sensor_actuator.md
+++ b/docs-gen/content/rule_set/data_entry/sensor_actuator.md
@@ -3,7 +3,12 @@ title: "Sensors & Actuators"
 date: 2019-08-04T12:37:03+02:00
 weight: 3
 ---
-A data entry defines a single sensor/actuator and its members. A data
+
+Sensors are signals to read values of properties in a vehicle. Values of signals typically change over time. Reading a sensor shall return the current actual value of the related property, e.g. the current speed or the current position of the seat. 
+
+Actuators are used to control the desired value of a property. Some properties in a vehicle cannot change instantly. A typical example is position of a seat or a window. Reading a value of an actuator shall return the current actual value, e.g. the current position of the seat, rather than the wanted/desired position. A typical example could be if someone wants to change the position of a seat from 0 to 100. This can be changed by setting the corresponding actuator to 100. If the actuator is read directly after the set request it will still return 0 as it might take some seconds before the seat reaches the wanted position of 100. If the seat by some reason is blocked or cannot be moved due to safety reasons it might never reach the wanted position. It is up to the vehicle to decide how long time it shall try to reach the desired value and what to do if it needs to give up.
+
+A data entry for a sensor or actuator defines its members. A data
 entry example is given below:
 
 ```YAML
@@ -21,8 +26,8 @@ Defines the dot-notated name of the data entry. Please note that
 all parental branches included in the name must be defined as well.
 
 **```type```**  
-Defines the type of the node. This can be ```branch```,
-```sensor```, ```actuator```, ```stream``` or attribute.
+Defines the type of the node. This can be `branch`,
+`sensor`, `actuator` or `attribute`.
 
 **```description```**  
 A description string to be included (when applicable) in the various


### PR DESCRIPTION
- Adding recommended naming convention for signals, attributes and branch
- Aligning whether attribute actually is a signal or not.
  Previously it was sometimes considered as signal, sometimes not. Now not!
- Clarifying expected behavior when setting and reading actuators
- Aligning documentation on how often attribute values can change
  Previously we said in some places that they never can change
  In some places that they can change, but normally not more than once per
  ignition cycle. Now we say that they can change.
- Removing the "stream" node type.

Also removing stream as this keyword no longer is supported.