### PR TITLE
Refactoring engine time signals

### DIFF
--- a/spec/Powertrain/CombustionEngine.vspec
+++ b/spec/Powertrain/CombustionEngine.vspec
@@ -136,6 +136,22 @@ Speed:
   max: 20000
   description: Engine speed measured as rotations per minute.
 
+
+EngineHours:
+  datatype: float
+  type: sensor
+  description: Accumulated time during engine lifetime with 'engine speed (rpm) > 0'.
+  unit: h
+
+IdleHours:
+  datatype: float
+  type: sensor
+  description: Accumulated idling time during engine lifetime.
+               Definition of idling is not standardized.
+  comment: Vehicles may calculate accumulated idle time for an engine.
+           It might be based on engine speed (rpm) below a certain limit or any other mechanism.
+  unit: h
+
 #
 # Engine coolant temperature
 #

--- a/spec/Vehicle/Vehicle.vspec
+++ b/spec/Vehicle/Vehicle.vspec
@@ -163,36 +163,6 @@ LowVoltageSystemState:
     ]
   description: State of the supply voltage of the control units (usually 12V).
 
-IgnitionOn:
-  datatype: boolean
-  type: sensor
-  description: Indicates whether the vehicle ignition is on or off.
-  deprecation: V2.2 replaced by LowVoltageSystemState
-
-IgnitionOnTime:
-  datatype: uint32
-  type: sensor
-  unit: s
-  description: Accumulated ignition on time in seconds.
-
-IgnitionOffTime:
-  datatype: uint32
-  type: sensor
-  unit: s
-  description: Accumulated ignition off time in seconds.
-
-DriveTime:
-  datatype: uint32
-  type: sensor
-  unit: s
-  description: Accumulated drive time in seconds.
-
-IdleTime:
-  datatype: uint32
-  type: sensor
-  unit: s
-  description: Accumulated idle time in seconds.
-
 Speed:
   datatype: float
   type: sensor


### PR DESCRIPTION
The old *Time signals were not well defined. The need to have signals form accumulated engine hours
have been verified, and idle hours also seem to be relatively normal,
but the others does not seem to be needed.

This commit propose two new signals to replace the old *Time signals

Fixes #356