### PR TITLE
Adding Time signal to VSS

### DIFF
--- a/spec/Vehicle/Vehicle.vspec
+++ b/spec/Vehicle/Vehicle.vspec
@@ -385,6 +385,15 @@ Trailer.Connected:
   description: Signal indicating if trailer is connected or not.
 
 #
+# Time
+#
+
+Time:
+  datatype: string
+  type: sensor
+  description: Current date and time in the vehicle, formatted according to ISO 8601.
+
+#
 # Location
 #
 


### PR DESCRIPTION
As of today we do not have a time signal in VSS. This PR proposes to add one. 

A possible use case could be internal applications that want to keep some form of log. Like all VSS-signals the delay, accuracy and update-frequency varies, so will likely be less useful for time-critical operations.

For now proposing it to be a sensor. Could alternatively be an an actuator if we want to allow Apps to set the time as well