### PR TITLE
[SPEC] Changed `enum` to `allowed`

### DIFF
--- a/docs-gen/content/rule_set/data_entry/enum.md
+++ b/docs-gen/content/rule_set/data_entry/enum.md
@@ -1,14 +1,13 @@
 ---
-title: "Enumerated Data Entries"
+title: "Defined Value restrictions"
 date: 2019-08-04T12:37:12+02:00
 weight: 5
 ---
 
-
-A data entry can optionally be enumerated, allowing it to be assigned a
-value from a specified set of values. An examples of a signal using enum is
-given below:
-
+Optionally it is possible to define an array of `allowed`, which will restrict the usage of the data entry in the implementation of the specification.
+It is expected, that any value not mentioned in the array is considered an error and the implementation of the specification shall react accordingly.
+The datatype of the array elements is the `datatype` defined for the data entry itself.
+For `attributes` it is possible to set optionally a default value.
 
 ```YAML
   
@@ -16,17 +15,15 @@ Charging.ChargePlugType:
   datatype: string
   type: attribute
   default: ccs
-  enum: [ 'type 1', 'type 2', 'ccs', 'chademo' ]
+  allowed: [ 'type 1', 'type 2', 'ccs', 'chademo' ]
   description: Type of charge plug available on the vehicle (CSS includes Type2).
 ```
 
-An enumerated signal entry has no ```min```, ```max```, or ```unit```
-element.
+If `allowed` is set, ```min```, ```max```, or ```unit``` cannot be defined.
 
-The ```enum``` element is an array of values, all of which must be specified
-in the enum list.  This signal can only be assigned one of the values
-specified in the enum list.
+The ```allowed``` element is an array of values, all of which must be specified
+in a list.  Only values can be assigned to the data entry, which are
+specified in this list.
 
-VSS supports enums for both integer datatypes as well as strings.
-The ```datatype``` specifier gives the type of the individual elements of the enum
+The ```datatype``` specifier gives the type of the individual elements of the `allowed`
 list.

--- a/docs-gen/content/rule_set/data_entry/sensor_actuator.md
+++ b/docs-gen/content/rule_set/data_entry/sensor_actuator.md
@@ -50,18 +50,18 @@ Recommended to start with a capital letter and end with a dot (`.`).
 The minimum value, within the interval of the given ```type```, that the
 data entry can be assigned.
 If omitted, the minimum value will be the "Min" value for the given type.
-Cannot be specified if ```enum``` is specified for the same data entry.
+Cannot be specified if ```allowed``` is defined for the same data entry.
 
 **```max```** *[optional]*  
 The maximum value, within the interval of the given ```type```, that the
 data entry can be assigned.
 If omitted, the maximum value will be the "Max" value for the given type.
-Cannot be specified if ```enum``` is specified for the same data entry.
+Cannot be specified if ```allowed``` is defined for the same data entry.
 
 **```unit```** *[optional]*    
 The unit of measurement that the data entry has. See [Unit
 Type](#data-unit-type) chapter for a list of available unit types. This
-cannot be specified if ```enum``` is specified as the signal type.
+cannot be specified if ```allowed``` is defined as the signal type.
 
 **```sensor```** *[optional]*  
 The sensing appliance used to produce the data entry.

--- a/spec/Body/Body.vspec
+++ b/spec/Body/Body.vspec
@@ -18,7 +18,7 @@ BodyType:
 RefuelPosition:
   datatype: string
   type: attribute
-  enum: ["front_left", "front_right", "middle_left", "middle_right", "rear_left", "rear_right"]
+  allowed: ["front_left", "front_right", "middle_left", "middle_right", "rear_left", "rear_right"]
   description: Location of the fuel cap or charge port.
 
 #
@@ -93,7 +93,7 @@ Windshield.Wiping:
 Windshield.Wiping.Status:
   datatype: string
   type: actuator
-  enum: ["off", "slow", "medium", "fast", "interval", "rainsensor"]
+  allowed: ["off", "slow", "medium", "fast", "interval", "rainsensor"]
   description: Wiper status.
 
 Windshield.IsHeatingOn:
@@ -150,7 +150,7 @@ ChargingPort:
 ChargingPort.Type:
   datatype: string
   type: attribute
-  enum: [ "unknown", "Not_Fitted", "AC_Type_1", "AC_Type_2", "AC_GBT", "AC_DC_Type_1_Combo", "AC_DC_Type_2_Combo", "DC_GBT", "DC_Chademo" ]
+  allowed: [ "unknown", "Not_Fitted", "AC_Type_1", "AC_Type_2", "AC_GBT", "AC_DC_Type_1_Combo", "AC_DC_Type_2_Combo", "DC_GBT", "DC_Chademo" ]
   default: "unknown"
   description: Indicates the primary charging type fitted to the vehicle.
 

--- a/spec/Cabin/Cabin.vspec
+++ b/spec/Cabin/Cabin.vspec
@@ -58,7 +58,7 @@ Sunroof.Position:
 Sunroof.Switch:
   datatype: string
   type: actuator
-  enum: [ "Inactive", "Close", "Open", "OneShotClose", "OneShotOpen", "TiltUp", "TiltDown" ]
+  allowed: [ "Inactive", "Close", "Open", "OneShotClose", "OneShotOpen", "TiltUp", "TiltDown" ]
   description: Switch controlling sliding action such as window, sunroof, or shade.
 
 Sunroof.Shade:
@@ -182,5 +182,5 @@ Convertible:
 Convertible.Status:
   datatype: string
   type: sensor
-  enum: ["undefined", "closed", "open", "closing", "opening", "stalled"]
+  allowed: ["undefined", "closed", "open", "closing", "opening", "stalled"]
   description: Roof status on convertible vehicles.

--- a/spec/Cabin/Infotainment.vspec
+++ b/spec/Cabin/Infotainment.vspec
@@ -16,7 +16,7 @@ Media:
 Media.Action:
   datatype: string
   type: actuator
-  enum: [ "unknown", "Stop", "Play", "FastForward", "FastBackward", "SkipForward",  "SkipBackward" ]
+  allowed: [ "unknown", "Stop", "Play", "FastForward", "FastBackward", "SkipForward",  "SkipBackward" ]
   description: Tells if the media was
 
 Media.Played:
@@ -26,7 +26,7 @@ Media.Played:
 Media.Played.Source:
   datatype: string
   type: actuator
-  enum: [ "unknown", "SiriusXM", "AM", "FM", "DAB", "TV",  "CD", "DVD", "AUX", "USB", "Disk", "Bluetooth", "Internet", "Voice", "Beep" ]
+  allowed: [ "unknown", "SiriusXM", "AM", "FM", "DAB", "TV",  "CD", "DVD", "AUX", "USB", "Disk", "Bluetooth", "Internet", "Voice", "Beep" ]
   description: Media selected for playback
 
 Media.Played.Artist:
@@ -102,41 +102,41 @@ HMI.CurrentLanguage:
 HMI.DateFormat:
   datatype: string
   type: actuator
-  enum: [ "YYYY MM DD", "DD MM YYYY", "MM DD YYYY", "YY MM DD", "DD MM YY", "MM DD YY"]
+  allowed: [ "YYYY MM DD", "DD MM YYYY", "MM DD YYYY", "YY MM DD", "DD MM YY", "MM DD YY"]
   description: Date format used in the current HMI
 
 HMI.TimeFormat:
   datatype: string
   type: actuator
-  enum: [ "12HR", "24HR" ]
+  allowed: [ "12HR", "24HR" ]
   description: Time format used in the current HMI
 
 HMI.DistanceUnit:
   datatype: string
   type: actuator
-  enum: [ "mi", "km" ]
+  allowed: [ "mi", "km" ]
   description: Distance unit used in the current HMI
 
 HMI.FuelEconomyUnits:
   datatype: string
   type: actuator
-  enum: [ "mpg_UK", "mpg_US", "mpl", "km/l", "l/100km" ]
+  allowed: [ "mpg_UK", "mpg_US", "mpl", "km/l", "l/100km" ]
   description: Fuel economy unit used in the current HMI
 
 HMI.EVEconomyUnits:
   datatype: string
   type: actuator
-  enum: [ "mi/kWh", "km/kWh", "kWh/100mi", "kWh/100km", "Wh/mi", "Wh/km" ]
+  allowed: [ "mi/kWh", "km/kWh", "kWh/100mi", "kWh/100km", "Wh/mi", "Wh/km" ]
   description: EV fuel economy unit used in the current HMI
 
 HMI.TemperatureUnit:
   datatype: string
   type: actuator
-  enum: [ "C", "F" ]
+  allowed: [ "C", "F" ]
   description: Temperature unit used in the current HMI
 
 HMI.DayNightMode:
   datatype: string
   type: actuator
-  enum: [ "Day", "Night" ]
+  allowed: [ "Day", "Night" ]
   description: Current display theme

--- a/spec/Cabin/SingleHVACStation.vspec
+++ b/spec/Cabin/SingleHVACStation.vspec
@@ -29,5 +29,5 @@ Temperature:
 AirDistribution:
   datatype: string
   type: actuator
-  enum: [ "up", "middle", "down" ]
+  allowed: [ "up", "middle", "down" ]
   description: Direction of airstream

--- a/spec/Cabin/SingleSliderSwitch.vspec
+++ b/spec/Cabin/SingleSliderSwitch.vspec
@@ -13,5 +13,5 @@
 Switch:
   datatype: string
   type: actuator
-  enum: [ "Inactive", "Close", "Open", "OneShotClose", "OneShotOpen" ]
+  allowed: [ "Inactive", "Close", "Open", "OneShotClose", "OneShotOpen" ]
   description: Switch controlling sliding action such as window, sunroof, or blind.

--- a/spec/Chassis/Chassis.vspec
+++ b/spec/Chassis/Chassis.vspec
@@ -144,7 +144,7 @@ SteeringWheel.Position:
   datatype: string
   type: attribute
   default: front_left
-  enum: ["front_left", "front_right"]
+  allowed: ["front_left", "front_right"]
   description: Position of the steering wheel on the left or right side of the vehicle.
 
 #

--- a/spec/OBD/OBD.vspec
+++ b/spec/OBD/OBD.vspec
@@ -54,7 +54,7 @@ Status.DTCCount:
 Status.IgnitionType:
   datatype: string
   type: sensor
-  enum: [ "spark", "compression" ]
+  allowed: [ "spark", "compression" ]
   description: Type of the ignition for ICE - spark = spark plug ignition, compression = self-igniting (Diesel engines)
 
 DTCList:
@@ -362,7 +362,7 @@ DriveCycleStatus.DTCCount:
 DriveCycleStatus.IgnitionType:
   datatype: string
   type: sensor
-  enum: [ "spark", "compression" ]
+  allowed: [ "spark", "compression" ]
   description: Type of the ignition for ICE - spark = spark plug ignition, compression = self-igniting (Diesel engines)
 
 ControlModuleVoltage:

--- a/spec/Powertrain/Battery.vspec
+++ b/spec/Powertrain/Battery.vspec
@@ -123,7 +123,7 @@ Charging.MaximumChargingCurrent:
 Charging.ChargePortFlap:
   datatype: string
   type: actuator
-  enum: [ 'open', 'closed' ]
+  allowed: [ 'open', 'closed' ]
   description: Status of the charge port cover, can potentially be controlled manually.
 
 Charging.IsChargingCableConnected:
@@ -135,13 +135,13 @@ Charging.ChargePlugType:
   datatype: string
   type: attribute
   default: ccs
-  enum: [ 'type 1', 'type 2', 'ccs', 'chademo' ]
+  allowed: [ 'type 1', 'type 2', 'ccs', 'chademo' ]
   description: Type of charge plug available on the vehicle (CSS includes Type2).
 
 Charging.Mode:
   datatype: string
   type: actuator
-  enum: [ 'manual', 'timer', 'grid' ]
+  allowed: [ 'manual', 'timer', 'grid' ]
   description: Control of the charge process - manually initiated (plug-in event, companion app, etc), timer-based or grid-controlled (eg ISO 15118).
 
 Charging.IsCharging:
@@ -153,7 +153,7 @@ Charging.IsCharging:
 Charging.StartStopCharging:
   datatype: string
   type: actuator
-  enum: [ 'start', 'stop' ]
+  allowed: [ 'start', 'stop' ]
   description: Start or stop the charging process.
 
 Charging.ChargeCurrent:
@@ -191,7 +191,7 @@ Charging.Timer:
 Charging.Timer.Mode:
   datatype: string
   type: actuator
-  enum: [ 'inactive', 'starttime', 'endtime' ]
+  allowed: [ 'inactive', 'starttime', 'endtime' ]
   description: "Defines timer mode for charging:
                'inactive' - no timer set, charging may start as soon as battery is connected to a charger.
                'starttime' - charging shall start at Charging.Timer.Time.

--- a/spec/Powertrain/CombustionEngine.vspec
+++ b/spec/Powertrain/CombustionEngine.vspec
@@ -39,7 +39,7 @@ Bore:
 Configuration:
   datatype: string
   type: attribute
-  enum: [ "unknown", "straight", "V", "boxer", "W",
+  allowed: [ "unknown", "straight", "V", "boxer", "W",
         "rotary", "radial", "square", "H", "U", "opposed", "X" ]
   description: Engine configuration.
   default: "unknown"
@@ -88,21 +88,21 @@ MaxTorque:
 AspirationType:
   datatype: string
   type: attribute
-  enum: [ "unknown", "natural", "supercharger", "turbocharger" ]
+  allowed: [ "unknown", "natural", "supercharger", "turbocharger" ]
   default: "unknown"
   description: Type of aspiration (natural, turbocharger, supercharger etc).
 
 FuelType:
   datatype: string
   type: attribute
-  enum: [ "unknown", "gasoline", "diesel", "E85", "CNG" ]
+  allowed: [ "unknown", "gasoline", "diesel", "E85", "CNG" ]
   default: "unknown"
   description: Type of fuel that the engine runs on.
 
 EngineOilLevel:
   datatype: string
   type: sensor
-  enum: [ 
+  allowed: [ 
     "critically_low",  # Critically low, immediate action required
     "low",             # Level below recommended range, but not critical
     "normal",          # Within normal range, no need for driver action

--- a/spec/Powertrain/FuelSystem.vspec
+++ b/spec/Powertrain/FuelSystem.vspec
@@ -13,14 +13,14 @@
 FuelType:
   datatype: string
   type: attribute
-  enum: [ "unknown", "gasoline", "diesel", "electric", "hybrid", "E85", "CNG", "LPG" ]
+  allowed: [ "unknown", "gasoline", "diesel", "electric", "hybrid", "E85", "CNG", "LPG" ]
   default: "unknown"
   description: Defines the fuel type of the vehicle.
 
 HybridType:
   datatype: string
   type: attribute
-  enum: [ "unknown", "not_applicable", "stop_start", "belt_ISG", "CIMG", "PHEV" ]
+  allowed: [ "unknown", "not_applicable", "stop_start", "belt_ISG", "CIMG", "PHEV" ]
   default: "unknown"
   description: Defines the hybrid type of the vehicle.
 

--- a/spec/Powertrain/Transmission.vspec
+++ b/spec/Powertrain/Transmission.vspec
@@ -16,7 +16,7 @@
 Type:
   datatype: string
   type: attribute
-  enum: [ "unknown", "sequential", "H", "automatic", "DSG", "CVT" ]
+  allowed: [ "unknown", "sequential", "H", "automatic", "DSG", "CVT" ]
   default: "unknown"
   description: Transmission type.
 
@@ -30,7 +30,7 @@ GearCount:
 DriveType:
   datatype: string
   type: attribute
-  enum: [ "unknown", "forward wheel drive", "rear wheel drive", "all wheel drive" ]
+  allowed: [ "unknown", "forward wheel drive", "rear wheel drive", "all wheel drive" ]
   default: "unknown"
   description: Drive type.
 
@@ -77,7 +77,7 @@ SelectedGear:
 PerformanceMode:
   datatype: string
   type: actuator
-  enum: [ "normal", "sport", "economy", "snow", "rain" ]
+  allowed: [ "normal", "sport", "economy", "snow", "rain" ]
   description: Current gearbox performance mode.
 
 
@@ -87,7 +87,7 @@ PerformanceMode:
 GearChangeMode:
   datatype: string
   type: actuator
-  enum: [ "manual", "automatic" ]
+  allowed: [ "manual", "automatic" ]
   description: Is the gearbox in automatic or manual (paddle) mode.
 
 

--- a/spec/Private/CARFIT/Chassis/Wheel.vspec
+++ b/spec/Private/CARFIT/Chassis/Wheel.vspec
@@ -45,7 +45,7 @@ Tire.Condition:
 
 Tire.Condition.Tread:
   type: String,
-  enum: [ good, flat spot, low, uneven, separated, other damage ]
+  allowed: [ good, flat spot, low, uneven, separated, other damage ]
   description: The condition of the tread
 
 Tire.Condition.Sidewall:
@@ -73,7 +73,7 @@ Wheel.Balance:
 
 Wheel.Condition:
   type: String,
-  enum: [ good, dents, cracks, flat spot, other damage ]
+  allowed: [ good, dents, cracks, flat spot, other damage ]
   description: The condition of the tread
 
 Wheel.Bearing:

--- a/spec/Vehicle/Vehicle.vspec
+++ b/spec/Vehicle/Vehicle.vspec
@@ -156,7 +156,7 @@ VehicleIdentification.KnownVehicleDamages:
 LowVoltageSystemState:
   datatype: string
   type: sensor
-  enum: [
+  allowed: [
     "UNDEFINED", # State of low voltage system not known
     "LOCK",      # Low voltage system off, steering lock or equivalent engaged
     "OFF",       # Low voltage system off, steering lock or equivalent not engaged


### PR DESCRIPTION
Currently `enum` is used for restrictions on allowed values
for a specific data entry. This causes confusions about
usage and specification  as #323 shows.

This commit changes `enum` to `allowedValues` for spec files
and documentation.

Signed-off-by: Daniel Wilms <Daniel.DW.Wilms@bmw.de>