### PR TITLE
Removing signals deprecated in v2.x

### DIFF
--- a/spec/Cabin/Infotainment.vspec
+++ b/spec/Cabin/Infotainment.vspec
@@ -90,61 +90,6 @@ Navigation.DestinationSet.Longitude:
   unit: degrees
   description: Longitude of destination
 
-Navigation.CurrentLocation:
-  type: branch
-  description: The current latitude and longitude of the vehicle.
-  deprecation: V2.1 moved to Vehicle.CurrentLocation
-
-Navigation.CurrentLocation.Latitude:
-  datatype: double
-  type: sensor
-  min: -90
-  max: 90
-  unit: degrees
-  description: Current latitude of vehicle, as reported by GPS.
-  deprecation: V2.1 moved to Vehicle.CurrentLocation.Latitude
-
-Navigation.CurrentLocation.Longitude:
-  datatype: double
-  type: sensor
-  min: -180
-  max: 180
-  unit: degrees
-  description: Current longitude of vehicle, as reported by GPS.
-  deprecation: V2.1 moved to Vehicle.CurrentLocation.Longitude
-
-Navigation.CurrentLocation.Heading:
-  datatype: double
-  type: sensor
-  min: 0
-  max: 360
-  unit: degrees
-  description: Current magnetic compass heading, in degrees.
-  deprecation: V2.1 moved to Vehicle.CurrentLocation.Heading
-
-Navigation.CurrentLocation.Accuracy:
-  datatype: double
-  type: sensor
-  unit: m
-  description: Accuracy level of the latitude and longitude coordinates in meters.
-  deprecation: V2.1 moved to Vehicle.CurrentLocation.Accuracy
-
-Navigation.CurrentLocation.Altitude:
-  datatype: double
-  type: sensor
-  unit: m
-  description: Current elevation of the position in meters.
-  deprecation: V2.1 moved to Vehicle.CurrentLocation.Altitude
-
-Navigation.CurrentLocation.Speed:
-  datatype: uint16
-  type: sensor
-  min: 0
-  max: 250
-  unit: km/h
-  description: Vehicle speed, as sensed by the GPS receiver.
-  deprecation: V2.1 removed because doubled with Vehicle.Speed
-
 HMI:
   type: branch
   description: HMI related signals

--- a/spec/Chassis/Chassis.vspec
+++ b/spec/Chassis/Chassis.vspec
@@ -10,57 +10,6 @@
 # Chassis signals and attributes
 #
 
-#
-# Vehicle Weight and Dimension attributes
-#
-CurbWeight:
-  datatype: uint16
-  type: attribute
-  default: 0
-  unit: kg
-  description: Vehicle curb weight, in kg, including all liquids and full tank of fuel, but no cargo or passengers.
-  deprecation: V2.1 moved to Vehicle.CurbWeight
-
-GrossWeight:
-  datatype: uint16
-  type: attribute
-  default: 0
-  unit: kg
-  description: Curb weight of vehicle, including all liquids and full tank of fuel and full load of cargo and passengers.
-  deprecation: V2.1 moved to Vehicle.GrossWeight
-
-TowWeight:
-  datatype: uint16
-  type: attribute
-  default: 0
-  unit: kg
-  description: Maximum weight, in kilos, of trailer.
-  deprecation: V2.1 moved to Vehicle.TowWeight
-
-Length:
-  datatype: uint16
-  type: attribute
-  default: 0
-  unit: mm
-  description: Overall vehicle length, in mm.
-  deprecation: V2.1 moved to Vehicle.Length
-
-Height:
-  datatype: uint16
-  type: attribute
-  default: 0
-  unit: mm
-  description: Overall vehicle height, in mm.
-  deprecation: V2.1 moved to Vehicle.Height
-
-Width:
-  datatype: uint16
-  type: attribute
-  default: 0
-  unit: mm
-  description: Overall vehicle width, in mm.
-  deprecation: V2.1 moved to Vehicle.Width
-
 Wheelbase:
   datatype: uint16
   type: attribute
@@ -229,17 +178,3 @@ Brake.PedalPosition:
   unit: percent
   description: Brake pedal position as percent. 0 = Not depressed. 100 = Fully depressed.
 
-
-#
-# Trailer
-#
-Trailer:
-  type: branch
-  description: Trailer signals
-  deprecation: V2.1 moved to Vehicle.Trailer
-
-Trailer.Connected:
-  datatype: boolean
-  type: sensor
-  description: Signal indicating if trailer is connected or not.
-  deprecation: V2.1 moved to Vehicle.Trailer.Connected

--- a/spec/Powertrain/Transmission.vspec
+++ b/spec/Powertrain/Transmission.vspec
@@ -39,19 +39,6 @@ DriveType:
 #
 
 #
-# Current vehicle speed
-#
-Speed:
-  datatype: int32
-  type: sensor
-  min: -250
-  max: 250
-  unit: km/h
-  description: Vehicle speed, as sensed by the gearbox.
-  deprecation: V2.1 removed because doubled with Vehicle.Speed
-
-
-#
 # Current odometer reading for the transmission
 #
 # Note that this signal refers to the distance travelled by the transmission and not the vehicle.
@@ -65,19 +52,6 @@ TravelledDistance:
   type: sensor
   unit: km
   description: Odometer reading, total distance travelled during the lifetime of the transmission.
-
-
-#
-# Current gear
-#
-Gear:
-  datatype: int8
-  type: actuator
-  min: -1
-  max: 16
-  description: Current gear. 0=Neutral. -1=Reverse
-  deprecation: V2.2 replaced by CurrentGear and SelectedGear
-
 
 #
 # Current gear

--- a/spec/Vehicle/Vehicle.vspec
+++ b/spec/Vehicle/Vehicle.vspec
@@ -261,13 +261,6 @@ RoofLoad:
   unit: kg
   description: The permitted total weight of cargo and installations (e.g. a roof rack) on top of the vehicle.
 
-accelerationTime:
-  datatype: int16
-  type: attribute
-  unit: s
-  description: The time needed to accelerate the vehicle from a given start velocity to a given target velocity.
-  deprecation: V2.1 removed as ambiguous definition (start/stop-speed not defined)
-
 cargoVolume:
   datatype: float
   type: attribute


### PR DESCRIPTION
According to https://github.com/COVESA/vehicle_signal_specification/blob/master/docs-gen/content/rule_set/basics.md
deprecated signals shall be removed in second minor or next major.
As we now are working towards v3.0 it is time to remove all deprecated as part of v2.x