### PR TITLE
Clarifying use of GNSS and Timestamp

### DIFF
--- a/docs-gen/content/rule_set/data_entry/data_types.md
+++ b/docs-gen/content/rule_set/data_entry/data_types.md
@@ -41,6 +41,17 @@ arraysize: 5
 An example for the usage of `arrays` is `Vehicle.OBD.DTCList` which contains a list
 of Diagnostic Trouble Codes (DTCs) present in a vehicle.
 
+## Timestamps
+
+Timestamps are in VSS typically represented as strings, formatted according to ISO 8601.
+Timestamps shall be expressed in UTC (Coordinated Universal Time), with special UTC designator ("Z"). 
+Time resolution SHALL at least be seconds, with subsecond resolution as an optional degree of precision when desired.
+The time and date format shall be as shown below, where the sub-second data and delimiter is optional.
+
+```
+YYYY-MM-DDTHH:MM:SS.ssssssZ
+```
+
 ## Data Streams
 
 Data Entries, which describe sensors offering binary streams

--- a/spec/Cabin/Infotainment.vspec
+++ b/spec/Cabin/Infotainment.vspec
@@ -80,7 +80,7 @@ Navigation.DestinationSet.Latitude:
   min: -90
   max: 90
   unit: degrees
-  description: Latitude of destination
+  description: Latitude of destination according to WGS 84.
 
 Navigation.DestinationSet.Longitude:
   datatype: double
@@ -88,7 +88,7 @@ Navigation.DestinationSet.Longitude:
   min: -180
   max: 180
   unit: degrees
-  description: Longitude of destination
+  description: Longitude of destination according to WGS 84.
 
 HMI:
   type: branch

--- a/spec/Vehicle/Vehicle.vspec
+++ b/spec/Vehicle/Vehicle.vspec
@@ -358,7 +358,7 @@ CurrentLocation:
 CurrentLocation.Timestamp:
   datatype: string
   type: sensor
-  description: GNSS Timestamp for latest position, formatted according to ISO 8601.
+  description: GNSS Timestamp for latest position, formatted according to ISO 8601 with UTC time zone.
 
 CurrentLocation.Latitude:
   datatype: double
@@ -366,7 +366,7 @@ CurrentLocation.Latitude:
   min: -90
   max: 90
   unit: degrees
-  description: Current latitude of vehicle.
+  description: Current latitude of vehicle according to WGS 84.
 
 CurrentLocation.Longitude:
   datatype: double
@@ -374,7 +374,7 @@ CurrentLocation.Longitude:
   min: -180
   max: 180
   unit: degrees
-  description: Current longitude of vehicle.
+  description: Current longitude of vehicle according to WGS 84.
 
 CurrentLocation.Heading:
   datatype: double
@@ -394,5 +394,5 @@ CurrentLocation.Altitude:
   datatype: double
   type: sensor
   unit: m
-  description: Current elevation of the position.
+  description: Current altitude relative to WGS 84 reference ellipsoid.
 


### PR DESCRIPTION
This PR tries to improve two areas of VSS

**GNSS**

Previously we did not explicitly state that coordinates shall be based on WGS84, and the description on altitude was a bit ambiguous as it mentioned elevation. Now it clearly states that it is altitude over WGS84 reference ellipsoid.

(As I understand it altitude in WGS84 context refer to height over WGS84 reference ellipsoid, but elevation typically refers to height over WGS84 geoid (which varies depending on WGS84 revision used, e.g. EGM96, EGM2008)

**Timestamp**

We have recently started to specify that string formatted according to ISO 8601 shall be used for some signals. But ISO 8601 gives you a lot of alternatives and you do not even need to specify time zone, and then the string shall be interpreted as local time. We see no real reason to use anything else than UTC in signals, and we think it would be good to give additional details/recommendations in documentation.

The documentation proposal is reasonable aligned with what is specified by VISS and W3C:

https://www.w3.org/TR/NOTE-datetime
https://raw.githack.com/w3c/automotive/gh-pages/spec/VISSv2_Core.html#timestamp