### PR TITLE
Refactoring charge plug signals and clarifying enum naming recommendations

### DIFF
--- a/spec/Body/Body.vspec
+++ b/spec/Body/Body.vspec
@@ -140,21 +140,6 @@ Mirrors:
 #include ExteriorMirrors.vspec Mirrors
 
 ##
-# Charging Inlet definition
-##
-
-ChargingPort:
-  type: branch
-  description: Collects Information about the charging port.
-
-ChargingPort.Type:
-  datatype: string
-  type: attribute
-  allowed: [ "unknown", "Not_Fitted", "AC_Type_1", "AC_Type_2", "AC_GBT", "AC_DC_Type_1_Combo", "AC_DC_Type_2_Combo", "DC_GBT", "DC_Chademo" ]
-  default: "unknown"
-  description: Indicates the primary charging type fitted to the vehicle.
-
-##
 # Spoilers
 ##
 
@@ -165,4 +150,3 @@ RearMainSpoilerPosition:
   min: 0
   max: 100
   description: Rear spoiler position, 0% = Spoiler fully stowed. 100% = Spoiler fully exposed.
-

--- a/spec/Powertrain/Battery.vspec
+++ b/spec/Powertrain/Battery.vspec
@@ -134,9 +134,21 @@ Charging.IsChargingCableConnected:
 Charging.ChargePlugType:
   datatype: string
   type: attribute
-  default: ccs
-  allowed: [ 'type 1', 'type 2', 'ccs', 'chademo' ]
-  description: Type of charge plug available on the vehicle (CSS includes Type2).
+  enum: [
+    IEC_TYPE_1_AC,     # Yazaki
+    IEC_TYPE_2_AC,     # Mennekes
+    IEC_TYPE_3_AC,     # Scame
+    IEC_TYPE_4_DC,     # CHAdeMO
+    IEC_TYPE_1_CCS_DC, # Combo 1
+    IEC_TYPE_2_CCS_DC, # Combo 2
+    TESLA_ROADSTER,
+    TESLA_HPWC,
+    TESLA_SUPERCHARGER,
+    GBT_AC,
+    GBT_DC,
+    OTHER
+    ]
+  description: Type of charge plug available on the vehicle.
 
 Charging.Mode:
   datatype: string


### PR DESCRIPTION
Fixes #376

Merging the two existing signals to a common signal. Aligned with EvConnectorType in https://android.googlesource.com/platform/hardware/interfaces/+/master/automotive/vehicle/2.0/types.hal - it seems to be quite exhaustive and also include some Tesla-specific connectors.

As of today we are are a bit inconsistent on enum symbols (string literals) in VSS concerning style. Here using a pattern with underscore and upper case letters, but I am open to using a different pattern. As long as we do not use whitespace I am happy. As the signals involved in this change also are used as examples I took the liberty to also extend and change the documentation accordingly.

See https://www.evexpert.eu/eshop1/knowledge-center/connector-types-for-ev-charging-around-the-world
for general information on connector types