### PR TITLE
Adapting signal names to naming rules

### DIFF
--- a/spec/ADAS/ADAS.vspec
+++ b/spec/ADAS/ADAS.vspec
@@ -25,7 +25,7 @@
 
 CruiseControl:
   type: branch
-  description: Signals from Cruise Control system
+  description: Signals from Cruise Control system.
 
 CruiseControl.IsActive:
   datatype: boolean
@@ -37,9 +37,9 @@ CruiseControl.SpeedSet:
   datatype: float
   type: actuator
   unit: km/h
-  description: Set cruise control speed in kilometers per hour
+  description: Set cruise control speed in kilometers per hour.
 
-CruiseControl.Error:
+CruiseControl.IsError:
   datatype: boolean
   type: sensor
   description: Indicates if cruise control system incurred and error condition. True = Error. False = NoError.
@@ -49,19 +49,19 @@ CruiseControl.Error:
 #
 LaneDepartureDetection:
   type: branch
-  description: Signals from Land Departure Detection System
+  description: Signals from Lane Departure Detection System.
 
 LaneDepartureDetection.IsActive:
   datatype: boolean
   type: actuator
   description: Indicates if lane departure detection system is enabled. True = Enabled. False = Disabled.
 
-LaneDepartureDetection.Warning:
+LaneDepartureDetection.IsWarning:
   datatype: boolean
   type: sensor
-  description: Indicates if lane departure detection registered a lane departure
+  description: Indicates if lane departure detection registered a lane departure.
 
-LaneDepartureDetection.Error:
+LaneDepartureDetection.IsError:
   datatype: boolean
   type: sensor
   description: Indicates if lane departure system incurred an error condition. True = Error. False = No Error.
@@ -71,14 +71,14 @@ LaneDepartureDetection.Error:
 #
 ObstacleDetection:
   type: branch
-  description: Signals form Obstacle Sensor System
+  description: Signals form Obstacle Sensor System.
 
 ObstacleDetection.IsActive:
   datatype: boolean
   type: actuator
   description: Indicates if obstacle sensor system is enabled. True = Enabled. False = Disabled.
 
-ObstacleDetection.Error:
+ObstacleDetection.IsError:
   datatype: boolean
   type: sensor
   description: Indicates if obstacle sensor system incurred an error condition. True = Error. False = No Error.
@@ -90,7 +90,7 @@ ObstacleDetection.Error:
 #
 ABS:
   type: branch
-  description: Antilock Braking System signals
+  description: Antilock Braking System signals.
 
 ABS.IsActive:
   datatype: boolean
@@ -98,7 +98,7 @@ ABS.IsActive:
   description: Indicates if ABS is enabled. True = Enabled. False = Disabled.
 
 
-ABS.Error:
+ABS.IsError:
   datatype: boolean
   type: sensor
   description: Indicates if ABS incurred an error condition. True = Error. False = No Error.
@@ -114,14 +114,14 @@ ABS.IsEngaged:
 #
 TCS:
   type: branch
-  description: Traction Control System signals
+  description: Traction Control System signals.
 
 TCS.IsActive:
   datatype: boolean
   type: actuator
   description: Indicates if TCS is enabled. True = Enabled. False = Disabled.
 
-TCS.Error:
+TCS.IsError:
   datatype: boolean
   type: sensor
   description: Indicates if TCS incurred an error condition. True = Error. False = No Error.
@@ -137,14 +137,14 @@ TCS.IsEngaged:
 #
 ESC:
   type: branch
-  description: Electronic Stability Control System signals
+  description: Electronic Stability Control System signals.
 
 ESC.IsActive:
   datatype: boolean
   type: actuator
-  description: Indicates if ECS is enabled. True = Enabled. False = Disabled.
+  description: Indicates if ESC is enabled. True = Enabled. False = Disabled.
 
-ESC.Error:
+ESC.IsError:
   datatype: boolean
   type: sensor
   description: Indicates if ESC incurred an error condition. True = Error. False = No Error.

--- a/spec/Body/Body.vspec
+++ b/spec/Body/Body.vspec
@@ -13,37 +13,37 @@
 BodyType:
   datatype: string
   type: attribute
-  description: Body type code as defined by ISO 3779
+  description: Body type code as defined by ISO 3779.
 
 RefuelPosition:
   datatype: string
   type: attribute
   enum: ["front_left", "front_right", "middle_left", "middle_right", "rear_left", "rear_right"]
-  description: Location of the fuel cap or charge port
+  description: Location of the fuel cap or charge port.
 
 #
 # Hood description
 #
 Hood:
   type: branch
-  description: Hood status
+  description: Hood status.
 
 Hood.IsOpen:
   datatype: boolean
   type: actuator
-  description: hood open or closed. True = Open. False = Closed
+  description: Hood open or closed. True = Open. False = Closed.
 
 #
 # Trunk description
 #
 Trunk:
   type: branch
-  description: Trunk status
+  description: Trunk status.
 
 Trunk.IsOpen:
   datatype: boolean
   type: actuator
-  description: Trunk open or closed. True = Open. False = Closed
+  description: Trunk open or closed. True = Open. False = Closed.
 
 Trunk.IsLocked:
   datatype: boolean
@@ -56,7 +56,7 @@ Trunk.IsLocked:
 #
 Horn:
   type: branch
-  description: Horn signals
+  description: Horn signals.
 
 Horn.IsActive:
   datatype: boolean
@@ -69,9 +69,9 @@ Horn.IsActive:
 #
 Raindetection:
   type: branch
-  description: Rainsensor signals
+  description: Rainsensor signals.
 
-Raindetection.intensity:
+Raindetection.Intensity:
   datatype: uint8
   type: sensor
   unit: percent
@@ -84,32 +84,28 @@ Raindetection.intensity:
 Windshield:
   type: branch
   instances: ["Front", "Rear"]
-  description: Windshield signals
+  description: Windshield signals.
 
 Windshield.Wiping:
   type: branch
-  description: Windshield wiper signals
+  description: Windshield wiper signals.
 
 Windshield.Wiping.Status:
   datatype: string
   type: actuator
   enum: ["off", "slow", "medium", "fast", "interval", "rainsensor"]
-  description: Wiper status
+  description: Wiper status.
 
-Windshield.Heating:
-  type: branch
-  description: Windshield heater signals
-
-Windshield.Heating.Status:
+Windshield.IsHeatingOn:
   datatype: boolean
   type: actuator
-  description: Windshield heater status. 0 - off, 1 - on
+  description: Windshield heater status. False - off, True - on.
 
 Windshield.WasherFluid:
   type: branch
   description: Windshield washer fluid signals
 
-Windshield.WasherFluid.LevelLow:
+Windshield.WasherFluid.IsLevelLow:
   datatype: boolean
   type: sensor
   description: Low level indication for washer fluid. True = Level Low. False = Level OK.
@@ -127,7 +123,7 @@ Windshield.WasherFluid.Level:
 ##
 Lights:
   type: branch
-  description: All lights
+  description: All lights.
 
 # Include lights specification and attach it to the Lights branch
 #include ExteriorLights.vspec Lights
@@ -139,7 +135,7 @@ Lights:
 Mirrors:
   type: branch
   instances: ["Left", "Right"]
-  description: All mirrors
+  description: All mirrors.
 # Include mirrors specification and attach it to the Mirrors branch
 #include ExteriorMirrors.vspec Mirrors
 
@@ -149,14 +145,14 @@ Mirrors:
 
 ChargingPort:
   type: branch
-  description: Collects Information about the charging port
+  description: Collects Information about the charging port.
 
 ChargingPort.Type:
   datatype: string
   type: attribute
   enum: [ "unknown", "Not_Fitted", "AC_Type_1", "AC_Type_2", "AC_GBT", "AC_DC_Type_1_Combo", "AC_DC_Type_2_Combo", "DC_GBT", "DC_Chademo" ]
   default: "unknown"
-  description: Indicates the primary charging type fitted to the vehicle
+  description: Indicates the primary charging type fitted to the vehicle.
 
 ##
 # Spoilers

--- a/spec/Body/ExteriorLights.vspec
+++ b/spec/Body/ExteriorLights.vspec
@@ -13,54 +13,54 @@
 IsHighBeamOn:
   datatype: boolean
   type: actuator
-  description: Is high beam on
+  description: Is high beam on?
 
 IsLowBeamOn:
   datatype: boolean
   type: actuator
-  description: Is low beam on
+  description: Is low beam on?
 
 IsRunningOn:
   datatype: boolean
   type: actuator
-  description: Are running lights on
+  description: Are running lights on?
 
 IsBackupOn:
   datatype: boolean
   type: actuator
-  description: Is backup (reverse) light on
+  description: Is backup (reverse) light on?
 
 IsParkingOn:
   datatype: boolean
   type: actuator
-  description: Is parking light on
+  description: Is parking light on?
 
 IsBrakeOn:
   datatype: boolean
   type: actuator
-  description: Is brake light on
+  description: Is brake light on?
 
 IsRearFogOn:
   datatype: boolean
   type: actuator
-  description: Is rear fog light on
+  description: Is rear fog light on?
 
 IsFrontFogOn:
   datatype: boolean
   type: actuator
-  description: Is front fog light on
+  description: Is front fog light on?
 
 IsHazardOn:
   datatype: boolean
   type: actuator
-  description: Are hazards on
+  description: Are hazards on?
 
 IsLeftIndicatorOn:
   datatype: boolean
   type: actuator
-  description: Is left indicator flashing
+  description: Is left indicator flashing?
 
 IsRightIndicatorOn:
   datatype: boolean
   type: actuator
-  description: Is right indicator flashing
+  description: Is right indicator flashing?

--- a/spec/Body/ExteriorMirrors.vspec
+++ b/spec/Body/ExteriorMirrors.vspec
@@ -22,11 +22,7 @@ Pan:
   unit: percent
   description: Mirror pan as a percent. 0 = Center Position. 100 = Fully Left Position. -100 = Fully Right Position.
 
-Heating:
-  type: branch
-  description: Mirror heater signals
-
-Heating.Status:
+IsHeatingOn:
   datatype: boolean
   type: actuator
   description: Mirror Heater on or off. True = Heater On. False = Heater Off.

--- a/spec/Cabin/Cabin.vspec
+++ b/spec/Cabin/Cabin.vspec
@@ -33,7 +33,7 @@ HVAC:
 ##
 Infotainment:
   type: branch
-  description: Infotainment system
+  description: Infotainment system.
 
 
 #include Infotainment.vspec Infotainment
@@ -50,7 +50,7 @@ Sunroof.Position:
   type: sensor
   min: -100
   max: 100
-  description: Sunroof position. 0 = Fully closed 100 = Fully opened. -100 = Fully tilted
+  description: Sunroof position. 0 = Fully closed 100 = Fully opened. -100 = Fully tilted.
 
 #
 # Sunroof controlling switch.
@@ -63,7 +63,7 @@ Sunroof.Switch:
 
 Sunroof.Shade:
   type: branch
-  description: Sun roof shade status
+  description: Sun roof shade status.
 
 # Include shade specification also used by side and rear window.
 #include SingleShade.vspec Sunroof.Shade
@@ -73,13 +73,13 @@ Sunroof.Shade:
 #
 RearviewMirror:
   type: branch
-  description: Rearview mirror
+  description: Rearview mirror.
 
 RearviewMirror.DimmingLevel:
   datatype: uint8
   type: actuator
   unit: percent
-  description: Dimming level of rearview mirror. 0 = undimmed. 100 = fully dimmed
+  description: Dimming level of rearview mirror. 0 = undimmed. 100 = fully dimmed.
 
 
 ##
@@ -87,7 +87,7 @@ RearviewMirror.DimmingLevel:
 ##
 Lights:
   type: branch
-  description: Interior lights signals and sensors
+  description: Interior lights signals and sensors.
 
 # Include the lights specification and attach it under the Lights branch.x
 #include InteriorLights.vspec Lights
@@ -109,7 +109,7 @@ Door:
   instances:
     - Row[1,2]
     - ["Left","Right"]
-  description: All doors, including windows and switches
+  description: All doors, including windows and switches.
 #include SingleDoor.vspec Door
 
 # Default value based on instance declaration above with 2 rows and 2 doors in each row.
@@ -117,7 +117,7 @@ DoorCount:
   datatype: uint8
   type: attribute
   default: 4
-  description: Number of doors in vehicle
+  description: Number of doors in vehicle.
 
 
 
@@ -150,37 +150,37 @@ Seat:
 #
 # Seat attributes.
 #
-# Default value is position 1, i.e. a typical LHD vehicle
 DriverPosition:
   datatype: uint8
   type: attribute
   default: 1
   description: The position of the driver seat in row 1.
+  comment: Default value is position 1, i.e. a typical LHD vehicle.
 
-# Default value corresponds to two rows of seats
 SeatRowCount:
   datatype: uint8
   type: attribute
   default: 2
-  description: Number of seat rows in vehicle
+  description: Number of seat rows in vehicle.
+  comment: Default value corresponds to two rows of seats.
 
 
-# Default value corresponds to two seats in front row and 3 seats in second row
 SeatPosCount:
   datatype: uint8[]
   type: attribute
   default: [2, 3]
-  description: Number of seats across each row from the front to the rear
+  description: Number of seats across each row from the front to the rear.
+  comment: Default value corresponds to two seats in front row and 3 seats in second row.
 
 ##
 # Convertible roof status
 ##
 Convertible:
   type: branch
-  description: Convertible roof
+  description: Convertible roof.
 
 Convertible.Status:
   datatype: string
   type: sensor
   enum: ["undefined", "closed", "open", "closing", "opening", "stalled"]
-  description: Roof status on convertible vehicles
+  description: Roof status on convertible vehicles.

--- a/spec/Cabin/SingleSeat.vspec
+++ b/spec/Cabin/SingleSeat.vspec
@@ -17,7 +17,7 @@
 # the selected switch. The movement is normally supposed to continue until either the switch is released,
 # (== has the value false), or until the maximum/minimum value supported by the vehicle has been reached.
 
-HasPassenger:
+IsOccupied:
   datatype: boolean
   type: sensor
   description: Does the seat have a passenger in it.
@@ -127,7 +127,7 @@ SideBolster.Inflation:
 
 HeadRestraint:
   type: branch
-  description: Head restraint settings
+  description: Head restraint settings.
 
 HeadRestraint.Height:
   datatype: uint8
@@ -139,7 +139,7 @@ HeadRestraint.Height:
 
 Airbag:
   type: branch
-  description: Airbag signals
+  description: Airbag signals.
 
 Airbag.IsDeployed:
   datatype: boolean
@@ -153,136 +153,136 @@ Switch:
   type: branch
   description: Seat switch signals
 
-Switch.Warmer:
+Switch.IsWarmerEngaged:
   datatype: boolean
   type: actuator
-  description: Warmer switch for Seat heater (SingleSeat.Heating)
+  description: Warmer switch for Seat heater (SingleSeat.Heating).
 
-Switch.Cooler:
+Switch.IsCoolerEngaged:
   datatype: boolean
   type: actuator
-  description: Cooler switch for Seat heater (SingleSeat.Heating)
+  description: Cooler switch for Seat heater (SingleSeat.Heating).
 
-Switch.Forward:
+Switch.IsForwardEngaged:
   datatype: boolean
   type: actuator
-  description: Seat forward switch engaged (SingleSeat.Position)
+  description: Seat forward switch engaged (SingleSeat.Position).
 
-Switch.Backward:
+Switch.IsBackwardEngaged:
   datatype: boolean
   type: actuator
-  description: Seat backward switch engaged (SingleSeat.Position)
+  description: Seat backward switch engaged (SingleSeat.Position).
 
-Switch.Up:
+Switch.IsUpEngaged:
   datatype: boolean
   type: actuator
-  description: Seat up switch engaged (SingleSeat.Height)
+  description: Seat up switch engaged (SingleSeat.Height).
 
-Switch.Down:
+Switch.IsDownEngaged:
   datatype: boolean
   type: actuator
-  description: Seat down switch engaged (SingleSeat.Height)
+  description: Seat down switch engaged (SingleSeat.Height).
 
 Switch.HeadRestraint:
   type: branch
-  description: Switches for SingleSeat.HeadRestraint.Height
+  description: Switches for SingleSeat.HeadRestraint.Height.
 
-Switch.HeadRestraint.Up:
+Switch.HeadRestraint.IsUpEngaged:
   datatype: boolean
   type: actuator
-  description: Head restraint up switch engaged (SingleSeat.HeadRestraint.Height)
+  description: Head restraint up switch engaged (SingleSeat.HeadRestraint.Height).
 
-Switch.HeadRestraint.Down:
+Switch.HeadRestraint.IsDownEngaged:
   datatype: boolean
   type: actuator
-  description: Head restraint down switch engaged (SingleSeat.HeadRestraint.Height)
+  description: Head restraint down switch engaged (SingleSeat.HeadRestraint.Height).
 
 Switch.Massage:
   type: branch
-  description: Switches for SingleSeat.Massage
+  description: Switches for SingleSeat.Massage.
 
-Switch.Massage.Increase:
+Switch.Massage.IsIncreaseEngaged:
   datatype: boolean
   type: actuator
-  description: Increase massage level switch engaged (SingleSeat.Massage)
+  description: Increase massage level switch engaged (SingleSeat.Massage).
 
-Switch.Massage.Decrease:
+Switch.Massage.IsDecreaseEngaged:
   datatype: boolean
   type: actuator
-  description: Decrease massage level switch engaged (SingleSeat.Massage)
+  description: Decrease massage level switch engaged (SingleSeat.Massage).
 
 Switch.Recline:
   type: branch
-  description: Switches for SingleSeat.Recline
+  description: Switches for SingleSeat.Recline.
 
-Switch.Recline.Backward:
+Switch.Recline.IsBackwardEngaged:
   datatype: boolean
   type: actuator
-  description: Seatback recline backward switch engaged (SingleSeat.Recline)
+  description: Seatback recline backward switch engaged (SingleSeat.Recline).
 
-Switch.Recline.Forward:
+Switch.Recline.IsForwardEngaged:
   datatype: boolean
   type: actuator
-  description: Seatback recline forward switch engaged (SingleSeat.Recline)
+  description: Seatback recline forward switch engaged (SingleSeat.Recline).
 
 Switch.Cushion:
   type: branch
-  description: Switches for SingleSeat.Cushion
+  description: Switches for SingleSeat.Cushion.
 
-Switch.Cushion.Up:
+Switch.Cushion.IsUpEngaged:
   datatype: boolean
   type: actuator
-  description: Seat cushion up switch engaged (SingleSeat.Cushion.Height)
+  description: Seat cushion up switch engaged (SingleSeat.Cushion.Height).
 
-Switch.Cushion.Down:
+Switch.Cushion.IsDownEngaged:
   datatype: boolean
   type: actuator
-  description: Seat cushion down switch engaged (SingleSeat.Cushion.Height)
+  description: Seat cushion down switch engaged (SingleSeat.Cushion.Height).
 
-Switch.Cushion.Forward:
+Switch.Cushion.IsForwardEngaged:
   datatype: boolean
   type: actuator
-  description: Seat cushion forward/lengthen switch engaged (SingleSeat.Cushion.Length)
+  description: Seat cushion forward/lengthen switch engaged (SingleSeat.Cushion.Length).
 
-Switch.Cushion.Backward:
+Switch.Cushion.IsBackwardEngaged:
   datatype: boolean
   type: actuator
-  description: Seat cushion backward/shorten switch engaged (SingleSeat.Cushion.Length)
+  description: Seat cushion backward/shorten switch engaged (SingleSeat.Cushion.Length).
 
 Switch.Lumbar:
   type: branch
-  description: Switches for SingleSeat.Lumbar
+  description: Switches for SingleSeat.Lumbar.
 
-Switch.Lumbar.Up:
+Switch.Lumbar.IsUpEngaged:
   datatype: boolean
   type: actuator
-  description: Lumbar up switch engaged (SingleSeat.Lumbar.Height)
+  description: Lumbar up switch engaged (SingleSeat.Lumbar.Height).
 
-Switch.Lumbar.Down:
+Switch.Lumbar.IsDownEngaged:
   datatype: boolean
   type: actuator
-  description: Lumbar down switch engaged (SingleSeat.Lumbar.Height)
+  description: Lumbar down switch engaged (SingleSeat.Lumbar.Height).
 
-Switch.Lumbar.Inflate:
+Switch.Lumbar.IsInflateEngaged:
   datatype: boolean
   type: actuator
-  description: Lumbar inflation switch engaged (SingleSeat.Lumbar.Inflation)
+  description: Lumbar inflation switch engaged (SingleSeat.Lumbar.Inflation).
 
-Switch.Lumbar.Deflate:
+Switch.Lumbar.IsDeflateEngaged:
   datatype: boolean
   type: actuator
-  description: Lumbar deflation switch engaged (SingleSeat.Lumbar.Inflation)
+  description: Lumbar deflation switch engaged (SingleSeat.Lumbar.Inflation).
 
 Switch.SideBolster:
   type: branch
-  description: Switches for SingleSeat.SideBolster
+  description: Switches for SingleSeat.SideBolster.
 
-Switch.SideBolster.Inflate:
+Switch.SideBolster.IsInflateEngaged:
   datatype: boolean
   type: actuator
-  description: Side bolster inflation switch engaged (SingleSeat.SideBolster.Inflation)
+  description: Side bolster inflation switch engaged (SingleSeat.SideBolster.Inflation).
 
-Switch.SideBolster.Deflate:
+Switch.SideBolster.IsDeflateEngaged:
   datatype: boolean
   type: actuator
-  description: Side bolster deflation switch engaged (SingleSeat.SideBolster.Inflation)
+  description: Side bolster deflation switch engaged (SingleSeat.SideBolster.Inflation).

--- a/spec/Cabin/SingleWindow.vspec
+++ b/spec/Cabin/SingleWindow.vspec
@@ -9,10 +9,10 @@
 #
 # Definition of a Window
 #
-isOpen:
+IsOpen:
   datatype: boolean
   type: sensor
-  description: Is window open or closed
+  description: Is window open or closed?
 
 Position:
   datatype: uint8
@@ -22,7 +22,7 @@ Position:
   unit: percent
   description: Window position. 0 = Fully closed 100 = Fully opened.
 
-ChildLock:
+IsChildLockEngaged:
   datatype: boolean
   type: sensor
   description: Is window child lock engaged. True = Engaged. False = Disengaged.

--- a/spec/Chassis/Wheel.vspec
+++ b/spec/Chassis/Wheel.vspec
@@ -19,7 +19,7 @@ Brake.FluidLevel:
   unit: percent
   description: Brake fluid level as percent. 0 = Empty. 100 = Full.
 
-Brake.FluidLevelLow:
+Brake.IsFluidLevelLow:
   datatype: boolean
   type: sensor
   description: Brake fluid level status. True = Brake fluid level low. False = Brake fluid level OK.
@@ -29,7 +29,7 @@ Brake.PadWear:
   type: sensor
   description: Brake pad wear as percent. 0 = No Wear. 100 = Worn.
 
-Brake.BrakesWorn:
+Brake.IsBrakesWorn:
   datatype: boolean
   type: sensor
   description: Brake pad wear status. True = Worn. False = Not Worn.
@@ -40,15 +40,15 @@ Brake.BrakesWorn:
 #
 Tire:
   type: branch
-  description: Tire signals for wheel
+  description: Tire signals for wheel.
 
 Tire.Pressure:
   datatype: uint16
   type: sensor
   unit: kPa
-  description: Tire pressure in kilo-Pascal
+  description: Tire pressure in kilo-Pascal.
 
-Tire.PressureLow:
+Tire.IsPressureLow:
   datatype: boolean
   type: sensor
   description: Tire Pressure Status. True = Low tire pressure. False = Good tire pressure.

--- a/spec/Driver/Driver.vspec
+++ b/spec/Driver/Driver.vspec
@@ -15,9 +15,9 @@ DistractionLevel:
   datatype: float
   type: sensor
   unit: percent
-  description: Distraction level of the driver will be the level how much the driver is distracted, by multiple factors. E.g. Driving situation, acustical or optical signales inside the cockpit, phone calls
+  description: Distraction level of the driver will be the level how much the driver is distracted, by multiple factors. E.g. Driving situation, acustical or optical signales inside the cockpit, phone calls.
 
-EyesOnRoad:
+IsEyesOnRoad:
   datatype: boolean
   type: sensor
   description: Has driver the eyes on road or not?

--- a/spec/Identifier/Identifier.vspec
+++ b/spec/Identifier/Identifier.vspec
@@ -12,9 +12,9 @@
 Subject:
   datatype: string
   type: sensor
-  description: Subject for the authentification of the occupant. E.g. UserID 7331677
+  description: Subject for the authentication of the occupant. E.g. UserID 7331677.
   
 Issuer:
   datatype: string
   type: sensor
-  description: Unique Issuer for the authentification of the occupant. E.g. https://accounts.funcorp.com
+  description: Unique Issuer for the authentication of the occupant. E.g. https://accounts.funcorp.com.

--- a/spec/OBD/OBD.vspec
+++ b/spec/OBD/OBD.vspec
@@ -41,7 +41,7 @@ Status:
   type: branch
   description: PID 01 - OBD status
 
-Status.MIL:
+Status.IsMILOn:
   datatype: boolean
   type: sensor
   description: Malfunction Indicator Light (MIL) False = Off, True = On
@@ -200,7 +200,7 @@ OxygenSensorsIn4Banks:
   type: sensor
   description: PID 1D - Presence of oxygen sensors in 4 banks. Similar to PID 13, but [A0..A7] == [B1S1, B1S2, B2S1, B2S2, B3S1, B3S2, B4S1, B4S2]
 
-AuxInputStatus:
+IsPTOActive:
   datatype: boolean
   type: sensor
   description: PID 1E - Auxiliary input status (power take off)
@@ -349,7 +349,7 @@ DriveCycleStatus:
   type: branch
   description: PID 41 - OBD status for the current drive cycle
 
-DriveCycleStatus.MIL:
+DriveCycleStatus.IsMILOn:
   datatype: boolean
   type: sensor
   description: Malfunction Indicator Light (MIL) - False = Off, True = On

--- a/spec/Powertrain/FuelSystem.vspec
+++ b/spec/Powertrain/FuelSystem.vspec
@@ -15,20 +15,20 @@ FuelType:
   type: attribute
   enum: [ "unknown", "gasoline", "diesel", "electric", "hybrid", "E85", "CNG", "LPG" ]
   default: "unknown"
-  description: Defines the fuel type of the vehicle
+  description: Defines the fuel type of the vehicle.
 
 HybridType:
   datatype: string
   type: attribute
   enum: [ "unknown", "not_applicable", "stop_start", "belt_ISG", "CIMG", "PHEV" ]
   default: "unknown"
-  description: Defines the hybrid type of the vehicle
+  description: Defines the hybrid type of the vehicle.
 
 TankCapacity:
   datatype: float
   type: attribute
   unit: l
-  description: Capacity of the fuel tank in liters
+  description: Capacity of the fuel tank in liters.
 
 Level:
   datatype: uint8
@@ -73,12 +73,12 @@ TimeSinceStart:
   unit: s
   description: Time in seconds elapsed since start of current trip.
 
-EngineStopStartEnabled:
+IsEngineStopStartEnabled:
   datatype: boolean
   type: sensor
-  description: Indicates whether eco start stop is currently enabled
+  description: Indicates whether eco start stop is currently enabled.
 
-LowFuelLevel:
+IsFuelLevelLow:
   datatype: boolean
   type: sensor
-  description: Indicates that the fuel level is low (e.g. <50km range)
+  description: Indicates that the fuel level is low (e.g. <50km range).

--- a/spec/Vehicle/Service.vspec
+++ b/spec/Vehicle/Service.vspec
@@ -28,7 +28,7 @@
 # The criteria for setting "ServiceDue" is not specified by VSS.
 # It may, but do not need to, be based on DistanceToService and TimeToService.
 #
-ServiceDue:
+IsServiceDue:
   datatype: boolean
   type: sensor
   description: Indicates if vehicle needs service (of any kind). True = Service needed now or in the near future. False = No known need for service.

--- a/spec/Vehicle/Vehicle.vspec
+++ b/spec/Vehicle/Vehicle.vspec
@@ -17,31 +17,31 @@
 
 VersionVSS:
   type: branch
-  description: Supported Version of VSS
+  description: Supported Version of VSS.
 
 VersionVSS.Major:
   datatype: uint32
   type: attribute
   default: 3
-  description: Supported Version of VSS - Major version
+  description: Supported Version of VSS - Major version.
 
 VersionVSS.Minor:
   datatype: uint32
   type: attribute
   default: 0  
-  description: Supported Version of VSS - Minor version
+  description: Supported Version of VSS - Minor version.
 
 VersionVSS.Patch:
   datatype: uint32
   type: attribute
   default: 0
-  description: Supported Version of VSS - Patch version
+  description: Supported Version of VSS - Patch version.
 
 VersionVSS.Label:
   datatype: string
   type: attribute
   default: "develop"
-  description: Label to further describe the version
+  description: Label to further describe the version.
 
 #
 # Vehicle identification attributes.
@@ -49,99 +49,102 @@ VersionVSS.Label:
 
 VehicleIdentification:
   type: branch
-  description: Attributes that identify a vehicle
+  description: Attributes that identify a vehicle.
 
 VehicleIdentification.VIN:
   datatype: string
   type: attribute
-  description: 17-character Vehicle Identification Number (VIN) as defined by ISO 3779
+  description: 17-character Vehicle Identification Number (VIN) as defined by ISO 3779.
 
 VehicleIdentification.WMI:
   datatype: string
   type: attribute
-  description: 3-character World Manufacturer Identification (WMI) as defined by ISO 3780
+  description: 3-character World Manufacturer Identification (WMI) as defined by ISO 3780.
 
 VehicleIdentification.Brand:
   datatype: string
   type: attribute
-  description: Vehicle brand or manufacturer
+  description: Vehicle brand or manufacturer.
 
 VehicleIdentification.Model:
   datatype: string
   type: attribute
-  description: Vehicle model
+  description: Vehicle model.
 
 VehicleIdentification.Year:
   datatype: uint16
   type: attribute
-  description: Model year of the vehicle
+  description: Model year of the vehicle.
 
 
 #
-# Imports from schema.org/Car
-#
+# Imports from https://schema.org/Car
+# Names from https://schema.org/Car reused, but first character capitalized
+# Example: Original schema.org name: https://schema.org/acrissCode
+#          Name used in VSS: VehicleIdentification.AcrissCode
+# Note: Only a subset of the properties from https://schema.org/Car have been imported.
 
-VehicleIdentification.ACRISSCode:
+VehicleIdentification.AcrissCode:
   datatype: string
   type: attribute
   description: The ACRISS Car Classification Code is a code used by many car rental companies.
 
-VehicleIdentification.bodyType:
+VehicleIdentification.BodyType:
   datatype: string
   type: attribute
   description: Indicates the design and body style of the vehicle (e.g. station wagon, hatchback, etc.).
 
-VehicleIdentification.dateVehicleFirstRegistered:
+VehicleIdentification.DateVehicleFirstRegistered:
   datatype: string
   type: attribute
-  description: The date of the first registration of the vehicle with the respective public authorities.
+  description: The date in ISO 8601 format of the first registration of the vehicle with the respective public authorities.
 
-VehicleIdentification.meetsEmissionStandard:
+VehicleIdentification.MeetsEmissionStandard:
   datatype: string
   type: attribute
   description: Indicates that the vehicle meets the respective emission standard.
 
-VehicleIdentification.productionDate:
+VehicleIdentification.ProductionDate:
   datatype: string
   type: attribute
-  description: The date of production of the item, e.g. vehicle.
+  description: The date in ISO 8601 format of production of the item, e.g. vehicle.
 
-VehicleIdentification.purchaseDate:
+VehicleIdentification.PurchaseDate:
   datatype: string
   type: attribute
-  description: The date the item e.g. vehicle was purchased by the current owner.
+  description: The date in ISO 8601 format of the item e.g. vehicle was purchased by the current owner.
 
-VehicleIdentification.vehicleModelDate:
+VehicleIdentification.VehicleModelDate:
   datatype: string
   type: attribute
-  description: The release date of a vehicle model (often used to differentiate versions of the same make and model).
+  description: The release date in ISO 8601 format of a vehicle model (often used to differentiate versions of the same make and model).
 
-VehicleIdentification.vehicleConfiguration:
+VehicleIdentification.VehicleConfiguration:
   datatype: string
   type: attribute
   description: A short text indicating the configuration of the vehicle, e.g. '5dr hatchback ST 2.5 MT 225 hp' or 'limited edition'.
 
-VehicleIdentification.vehicleSeatingCapacity:
+VehicleIdentification.VehicleSeatingCapacity:
   datatype: uint16
   type: attribute
   description: The number of passengers that can be seated in the vehicle, both in terms of the physical space available, and in terms of limitations set by law.
 
-VehicleIdentification.vehicleSpecialUsage:
+VehicleIdentification.VehicleSpecialUsage:
   datatype: string
   type: attribute
   description: Indicates whether the vehicle has been used for special purposes, like commercial rental, driving school.
 
-VehicleIdentification.vehicleinteriorColor:
+VehicleIdentification.VehicleInteriorColor:
   datatype: string
   type: attribute
   description: The color or color combination of the interior of the vehicle.
 
-VehicleIdentification.vehicleinteriorType:
+VehicleIdentification.VehicleInteriorType:
   datatype: string
   type: attribute
   description: The type or material of the interior of the vehicle (e.g. synthetic fabric, leather, wood, etc.).
 
-VehicleIdentification.knownVehicleDamages:
+VehicleIdentification.KnownVehicleDamages:
   datatype: string
   type: attribute
   description: A textual description of known damages, both repaired and unrepaired.
@@ -167,7 +170,7 @@ Speed:
   datatype: float
   type: sensor
   unit: km/h
-  description: Vehicle speed
+  description: Vehicle speed.
 
 TravelledDistance:
   datatype: float
@@ -179,7 +182,7 @@ TripMeterReading:
   datatype: float
   type: sensor
   unit: km
-  description: Current trip meter reading
+  description: Current trip meter reading.
 
 AmbientAirTemperature:
   datatype: float
@@ -191,13 +194,13 @@ AmbientAirTemperature:
 IsMoving:
   datatype: boolean
   type: sensor
-  description: Indicates whether the vehicle is stationary or moving
+  description: Indicates whether the vehicle is stationary or moving.
 
 AverageSpeed:
   datatype: float
   type: sensor
   unit: km/h
-  description: Average speed for the current trip
+  description: Average speed for the current trip.
 
 
 #
@@ -205,7 +208,7 @@ AverageSpeed:
 #
 Acceleration:
   type: branch
-  description: Spatial acceleration
+  description: Spatial acceleration.
 
 Acceleration.Longitudinal:
   datatype: float
@@ -231,7 +234,7 @@ Acceleration.Vertical:
 #
 AngularVelocity:
   type: branch
-  description: Spatial rotation
+  description: Spatial rotation.
 
 AngularVelocity.Roll:
   datatype: int16
@@ -261,14 +264,14 @@ RoofLoad:
   unit: kg
   description: The permitted total weight of cargo and installations (e.g. a roof rack) on top of the vehicle.
 
-cargoVolume:
+CargoVolume:
   datatype: float
   type: attribute
   unit: l
   description: The available volume for cargo or luggage. For automobiles, this is usually the trunk volume.
   min: 0
 
-emissionsCO2:
+EmissionsCO2:
   datatype: int16
   type: attribute
   description: The CO2 emissions.
@@ -340,9 +343,9 @@ Width:
 #
 Trailer:
   type: branch
-  description: Trailer signals
+  description: Trailer signals.
 
-Trailer.Connected:
+Trailer.IsConnected:
   datatype: boolean
   type: sensor
   description: Signal indicating if trailer is connected or not.

--- a/spec/VehicleSignalSpecification.vspec
+++ b/spec/VehicleSignalSpecification.vspec
@@ -29,24 +29,6 @@ Vehicle:
 
 #include Vehicle/Vehicle.vspec Vehicle
 
-
-
-#
-# An uncontrolled private branch.
-#
-# Top level speed, location, and other vehicle state?
-# odo. trip.
-# Alias Speed -> Drivetrain.Transmission.Speed
-#
-# Global.Speed
-# Global.Location
-# Global.Odometer
-#
-# Keep to minimum
-#
-# Put in accuracy as attribute for signal
-#
-
 Vehicle.Private:
   type: branch
   description: Uncontrolled branch where non-public signals can be defined.


### PR DESCRIPTION
Making sure first character is upper case and that boolean signals
starts with "Is" as described by naming conventions in https://covesa.github.io/vehicle_signal_specification/rule_set/basics/

Also some other minor changes, like adding period at end of description when missing and removing branch if branch only has one member in a few situations.

Solves the warnings reported by https://github.com/COVESA/vss-tools/pull/128

Fixes #384 
Fixes #293 
Fixes #239