### PR TITLE
[BUILD] Changed `buildcheck.yaml` to `pyenv` and `Pipfile`

### DIFF
--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -12,23 +12,40 @@ jobs:
         with:
           submodules: true
 
-      - name: Setup Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.8
+      - name: Install pyenv
+        run: |
+          # Needed for using exact python version, which is
+          # required in `Pipfile`.
+          curl https://pyenv.run | bash
+          export PATH="$HOME/.pyenv/bin:$PATH"
+          pyenv install 3.8.12
 
       - name: Install python packages
         run: |
           python -V
+          python -m pip --quiet --no-input install --upgrade pip 
+          python -m pip --quiet --no-input install --upgrade pipenv wheel
           cd vss-tools
-          pip install -r requirements.txt
-          python setup.py -q install
-
+          pipenv install
+          pipenv run python setup.py -q install
+        env:
+          PIPENV_VENV_IN_PROJECT: 1
+          
       - name: Test mandatory targets
-        run: make travis_targets
+        run: |
+          pipenv install
+          pipenv run make travis_targets
+        env:
+          PIPENV_PIPFILE: ./vss-tools/Pipfile
+          PIPENV_VENV_IN_PROJECT: 1
 
       - name: Test optional targets. NOTE - always succeeds
-        run: make -k travis_optional || true
+        run: |
+          pipenv install
+          pipenv run make -k travis_optional || true
+        env:
+          PIPENV_PIPFILE: ./vss-tools/Pipfile
+          PIPENV_VENV_IN_PROJECT: 1
 
       - name: Install hugo
         env:


### PR DESCRIPTION
We changed in vss-tools from `requirements.txt` to
`Pipfile` and in order to update the submodule
we have to do the change here in VSS as well.

Updated `buildcheck.yaml`:
* changed to pyenv instead of python action
* Use `Pipfile` instead of `requirements.txt`

Related to: https://github.com/COVESA/vss-tools/pull/131

Signed-off-by: Daniel Wilms <Daniel.DW.Wilms@bmw.de>