### PR TITLE
Removing arbitrary min/max limits

### DIFF
--- a/spec/Cabin/SingleHVACStation.vspec
+++ b/spec/Cabin/SingleHVACStation.vspec
@@ -21,8 +21,6 @@ FanSpeed:
 Temperature:
   datatype: int8
   type: actuator
-  min: -50
-  max: 50
   unit: celsius
   description: Temperature
 

--- a/spec/Cabin/SingleSeat.vspec
+++ b/spec/Cabin/SingleSeat.vspec
@@ -64,17 +64,15 @@ Position:
   datatype: uint16
   type: actuator
   min: 0
-  max: 1000
   unit: mm
-  description: Seat horizontal position. 0 = Frontmost. 1000 = Rearmost.
+  description: Seat horizontal position. 0 = Frontmost.
 
 Height:
   datatype: uint16
   type: actuator
   min: 0
-  max: 1000
   unit: mm
-  description: Seat vertical position. 0 = Lowermost. 1000 = Uppermost.
+  description: Seat vertical position. 0 = Lowermost.
 
 Cushion:
   type: branch
@@ -84,17 +82,15 @@ Cushion.Height:
   datatype: uint16
   type: actuator
   min: 0
-  max: 500
   unit: mm
-  description: Height of the seat cushion (leg support), relative to seat. 0 = Lowermost. 500 = Uppermost.
+  description: Height of the seat cushion (leg support), relative to seat. 0 = Lowermost.
 
 Cushion.Length:
   datatype: uint16
   type: actuator
   min: 0
-  max: 500
   unit: mm
-  description: Forward length of cushion (leg support), relative to seat. 0 = Rearmost. 500 = Forwardmost.
+  description: Forward length of cushion (leg support), relative to seat. 0 = Rearmost.
 
 Lumbar:
   type: branch
@@ -111,8 +107,8 @@ Lumbar.Height:
   datatype: uint8
   type: actuator
   min: 0
-  max: 255
-  description: Lumbar support position. 0 = Lowermost. 255 = Uppermost.
+  unit: mm
+  description: Lumbar support position. 0 = Lowermost.
 
 SideBolster:
   type: branch
@@ -133,9 +129,8 @@ HeadRestraint.Height:
   datatype: uint8
   type: actuator
   min: 0
-  max: 255
   unit: mm
-  description: Height of head restraint. 0 = Bottommost. 255 = Uppermost.
+  description: Height of head restraint. 0 = Bottommost.
 
 Airbag:
   type: branch

--- a/spec/Powertrain/ElectricMotor.vspec
+++ b/spec/Powertrain/ElectricMotor.vspec
@@ -46,8 +46,6 @@ Rpm:
   datatype: int32
   type: sensor
   unit: rpm
-  min: -100000
-  max: 100000
   description: Motor rotational speed measured as rotations per minute. Negative values indicate reverse driving mode.
 
 
@@ -58,8 +56,6 @@ Temperature:
   datatype: int16
   type: sensor
   unit: celsius
-  min: -50
-  max: 200
   description: Motor temperature.
 
 
@@ -70,8 +66,6 @@ CoolantTemperature:
   datatype: int16
   type: sensor
   unit: celsius
-  min: -50
-  max: 200
   description: Motor coolant temperature (if applicable).
 
 
@@ -82,8 +76,6 @@ Power:
   datatype: int16
   type: sensor
   unit: kW
-  min: -2000
-  max: 2000
   description: Current motor power output. Negative values indicate regen mode.
 
 #
@@ -93,6 +85,4 @@ Torque:
   datatype: int16
   type: sensor
   unit: Nm
-  min: -5000
-  max: 5000
   description: Current motor torque. Negative values indicate regen mode.


### PR DESCRIPTION
Min/Max values in VSS can serve two purposes:
- Define a logical range, like -180 to 180 for longitude
  or 0 to 100 for percentage
- Define constraints for a particular vehicle,
  e.g. supported range for seat position

This PR removes constraints that are vehicle specific.
Even if they might be useful they shall not be specified in the
standard VSS file, but rather be specified in a vehicle specific
VSS-file , possibly using VSS layering mechanism.