### PR TITLE
Renaming "allowed" literals according to guidelines

### DIFF
--- a/docs-gen/content/rule_set/data_entry/allowed.md
+++ b/docs-gen/content/rule_set/data_entry/allowed.md
@@ -13,8 +13,8 @@ For `attributes` it is possible to optionally set a default value.
 SteeringWheel.Position:
   datatype: string
   type: attribute
-  default: FRONT_LEFT
-  allowed: [FRONT_LEFT, FRONT_RIGHT]
+  default: 'FRONT_LEFT'
+  allowed: ['FRONT_LEFT', 'FRONT_RIGHT']
   description: Position of the steering wheel on the left or right side of the vehicle.
 
 ```
@@ -30,7 +30,7 @@ list.
 
 For string values used for `default` and `allowed` statements it is recommended to start with `A-Z`
 and then use only `A-Z`, `0-9` and underscore (`_`).
-Single(`'`) and double (`"`) quotes shall be used only if necessary, and are not needed if the naming recommendation is followed.
+It is recommended to use single quotes (`'`) as tooling otherwise might handle literals like `OFF` as boolean values with unexpected result.
 It is recommended not to specify a dedicated value corresponding to "unknown" or "undefined" unless there is a relevant use-case for that particular signal.
 The background is that a signal with an array of allowed values shall be handled just as any other signal.
 If e.g. the value of current speed or vehicle weight is unknown, then the vehicle shall not publish the corresponding signal.

--- a/spec/ADAS/ADAS.vspec
+++ b/spec/ADAS/ADAS.vspec
@@ -28,15 +28,15 @@ ActiveAutonomyLevel:
   datatype: string
   type: sensor
   allowed: [
-    SAE_0, 
-    SAE_1,
-    SAE_2_DISENGAGING,
-    SAE_2,   
-    SAE_3_DISENGAGING, # Level 3 AD functions will disengage, driver notified
-    SAE_3,  
-    SAE_4_DISENGAGING, # Level 4 AD functions will disengage, driver notified   
-    SAE_4,
-    SAE_5
+    'SAE_0',
+    'SAE_1',
+    'SAE_2_DISENGAGING',
+    'SAE_2',
+    'SAE_3_DISENGAGING', # Level 3 AD functions will disengage, driver notified
+    'SAE_3',
+    'SAE_4_DISENGAGING', # Level 4 AD functions will disengage, driver notified   
+    'SAE_4',
+    'SAE_5'
   ]
   description: Indicates the currently active level of autonomy according to SAE J3016 taxonomy.
   comment: Follows https://www.sae.org/news/2019/01/sae-updates-j3016-automated-driving-graphic 
@@ -52,12 +52,12 @@ SupportedAutonomyLevel:
   datatype: string
   type: attribute
   allowed: [
-    SAE_0, 
-    SAE_1,
-    SAE_2,   
-    SAE_3,     
-    SAE_4,
-    SAE_5
+    'SAE_0',
+    'SAE_1',
+    'SAE_2',
+    'SAE_3',
+    'SAE_4',
+    'SAE_5'
   ]
   description: Indicates the highest level of autonomy according to SAE J3016 taxonomy the vehicle is capable of.
 

--- a/spec/Body/Body.vspec
+++ b/spec/Body/Body.vspec
@@ -18,7 +18,7 @@ BodyType:
 RefuelPosition:
   datatype: string
   type: attribute
-  allowed: ["front_left", "front_right", "middle_left", "middle_right", "rear_left", "rear_right"]
+  allowed: ['FRONT_LEFT', 'FRONT_RIGHT', 'MIDDLE_LEFT', 'MIDDLE_RIGHT', 'REAR_LEFT', 'REAR_RIGHT']
   description: Location of the fuel cap or charge port.
 
 #
@@ -93,7 +93,7 @@ Windshield.Wiping:
 Windshield.Wiping.Status:
   datatype: string
   type: actuator
-  allowed: ["off", "slow", "medium", "fast", "interval", "rainsensor"]
+  allowed: ['OFF', 'SLOW', 'MEDIUM', 'FAST', 'INTERVAL', 'RAIN_SENSOR']
   description: Wiper status.
 
 Windshield.IsHeatingOn:
@@ -150,8 +150,8 @@ ChargingPort:
 ChargingPort.Type:
   datatype: string
   type: attribute
-  allowed: [ "unknown", "Not_Fitted", "AC_Type_1", "AC_Type_2", "AC_GBT", "AC_DC_Type_1_Combo", "AC_DC_Type_2_Combo", "DC_GBT", "DC_Chademo" ]
-  default: "unknown"
+  allowed: ['UNKNOWN', 'NOT_FITTED', 'AC_TYPE_1', 'AC_TYPE_2', 'AC_GBT', 'AC_DC_TYPE_1_COMBO', 'AC_DC_TYPE_2_COMBO', 'DC_GBT', 'DC_CHADEMO']
+  default: UNKNOWN
   description: Indicates the primary charging type fitted to the vehicle.
 
 ##

--- a/spec/Cabin/Cabin.vspec
+++ b/spec/Cabin/Cabin.vspec
@@ -58,7 +58,7 @@ Sunroof.Position:
 Sunroof.Switch:
   datatype: string
   type: actuator
-  allowed: [ "Inactive", "Close", "Open", "OneShotClose", "OneShotOpen", "TiltUp", "TiltDown" ]
+  allowed: ['INACTIVE', 'CLOSE', 'OPEN', 'ONE_SHOT_CLOSE', 'ONE_SHOT_OPEN', 'TILT_UP', 'TILT_DOWN']
   description: Switch controlling sliding action such as window, sunroof, or shade.
 
 Sunroof.Shade:
@@ -182,5 +182,5 @@ Convertible:
 Convertible.Status:
   datatype: string
   type: sensor
-  allowed: ["undefined", "closed", "open", "closing", "opening", "stalled"]
+  allowed: ['UNDEFINED', 'CLOSED', 'OPEN', 'CLOSING', 'OPENING', 'STALLED']
   description: Roof status on convertible vehicles.

--- a/spec/Cabin/Infotainment.vspec
+++ b/spec/Cabin/Infotainment.vspec
@@ -16,7 +16,7 @@ Media:
 Media.Action:
   datatype: string
   type: actuator
-  allowed: [ "unknown", "Stop", "Play", "FastForward", "FastBackward", "SkipForward",  "SkipBackward" ]
+  allowed: ['UNKNOWN', 'STOP', 'PLAY', 'FAST_FORWARD', 'FAST_BACKWARD', 'SKIP_FORWARD', 'SKIP_BACKWARD']
   description: Tells if the media was
 
 Media.Played:
@@ -26,7 +26,7 @@ Media.Played:
 Media.Played.Source:
   datatype: string
   type: actuator
-  allowed: [ "unknown", "SiriusXM", "AM", "FM", "DAB", "TV",  "CD", "DVD", "AUX", "USB", "Disk", "Bluetooth", "Internet", "Voice", "Beep" ]
+  allowed: ['UNKNOWN', 'SIRIUS_XM', 'AM', 'FM', 'DAB', 'TV', 'CD', 'DVD', 'AUX', 'USB', 'DISK', 'BLUETOOTH', 'INTERNET', 'VOICE', 'BEEP']
   description: Media selected for playback
 
 Media.Played.Artist:
@@ -102,41 +102,41 @@ HMI.CurrentLanguage:
 HMI.DateFormat:
   datatype: string
   type: actuator
-  allowed: [ "YYYY MM DD", "DD MM YYYY", "MM DD YYYY", "YY MM DD", "DD MM YY", "MM DD YY"]
+  allowed: ['YYYY_MM_DD', 'DD_MM_YYYY', 'MM_DD_YYYY', 'YY_MM_DD', 'DD_MM_YY', 'MM_DD_YY']
   description: Date format used in the current HMI
 
 HMI.TimeFormat:
   datatype: string
   type: actuator
-  allowed: [ "12HR", "24HR" ]
+  allowed: ['HR_12', 'HR_24']
   description: Time format used in the current HMI
 
 HMI.DistanceUnit:
   datatype: string
   type: actuator
-  allowed: [ "mi", "km" ]
+  allowed: ['MILES', 'KILOMETERS']
   description: Distance unit used in the current HMI
 
 HMI.FuelEconomyUnits:
   datatype: string
   type: actuator
-  allowed: [ "mpg_UK", "mpg_US", "mpl", "km/l", "l/100km" ]
+  allowed: ['MPG_UK', 'MPG_US', 'MILES_PER_LITER', 'KILOMETERS_PER_LITER', 'LITERS_PER_100_KILOMETERS']
   description: Fuel economy unit used in the current HMI
 
 HMI.EVEconomyUnits:
   datatype: string
   type: actuator
-  allowed: [ "mi/kWh", "km/kWh", "kWh/100mi", "kWh/100km", "Wh/mi", "Wh/km" ]
+  allowed: ['MILES_PER_KILOWATT_HOUR', 'KILOMETERS_PER_KILOWATT_HOUR', 'KILOWATT_HOURS_PER_100_MILES', 'KILOWATT_HOURS_PER_100_KILOMETERS', 'WATT_HOURS_PER_MILE', 'WATT_HOURS_PER_KILOMETER']
   description: EV fuel economy unit used in the current HMI
 
 HMI.TemperatureUnit:
   datatype: string
   type: actuator
-  allowed: [ "C", "F" ]
+  allowed: ['C', 'F']
   description: Temperature unit used in the current HMI
 
 HMI.DayNightMode:
   datatype: string
   type: actuator
-  allowed: [ "Day", "Night" ]
+  allowed: ['DAY', 'NIGHT']
   description: Current display theme

--- a/spec/Cabin/SingleHVACStation.vspec
+++ b/spec/Cabin/SingleHVACStation.vspec
@@ -27,5 +27,5 @@ Temperature:
 AirDistribution:
   datatype: string
   type: actuator
-  allowed: [ "up", "middle", "down" ]
+  allowed: ['UP', 'MIDDLE', 'DOWN']
   description: Direction of airstream

--- a/spec/Cabin/SingleSliderSwitch.vspec
+++ b/spec/Cabin/SingleSliderSwitch.vspec
@@ -13,5 +13,5 @@
 Switch:
   datatype: string
   type: actuator
-  allowed: [ "Inactive", "Close", "Open", "OneShotClose", "OneShotOpen" ]
+  allowed: ['INACTIVE', 'CLOSE', 'OPEN', 'ONE_SHOT_CLOSE', 'ONE_SHOT_OPEN']
   description: Switch controlling sliding action such as window, sunroof, or blind.

--- a/spec/Chassis/Chassis.vspec
+++ b/spec/Chassis/Chassis.vspec
@@ -143,8 +143,8 @@ SteeringWheel.Extension:
 SteeringWheel.Position:
   datatype: string
   type: attribute
-  default: front_left
-  allowed: ["front_left", "front_right"]
+  default: 'FRONT_LEFT'
+  allowed: ['FRONT_LEFT', 'FRONT_RIGHT']
   description: Position of the steering wheel on the left or right side of the vehicle.
 
 #

--- a/spec/OBD/OBD.vspec
+++ b/spec/OBD/OBD.vspec
@@ -54,7 +54,7 @@ Status.DTCCount:
 Status.IgnitionType:
   datatype: string
   type: sensor
-  allowed: [ "spark", "compression" ]
+  allowed: ['SPARK', 'COMPRESSION']
   description: Type of the ignition for ICE - spark = spark plug ignition, compression = self-igniting (Diesel engines)
 
 DTCList:
@@ -362,7 +362,7 @@ DriveCycleStatus.DTCCount:
 DriveCycleStatus.IgnitionType:
   datatype: string
   type: sensor
-  allowed: [ "spark", "compression" ]
+  allowed: ['SPARK', 'COMPRESSION']
   description: Type of the ignition for ICE - spark = spark plug ignition, compression = self-igniting (Diesel engines)
 
 ControlModuleVoltage:

--- a/spec/Powertrain/Battery.vspec
+++ b/spec/Powertrain/Battery.vspec
@@ -123,7 +123,7 @@ Charging.MaximumChargingCurrent:
 Charging.ChargePortFlap:
   datatype: string
   type: actuator
-  allowed: [ 'open', 'closed' ]
+  allowed: ['OPEN', 'CLOSED']
   description: Status of the charge port cover, can potentially be controlled manually.
 
 Charging.IsChargingCableConnected:
@@ -134,14 +134,14 @@ Charging.IsChargingCableConnected:
 Charging.ChargePlugType:
   datatype: string
   type: attribute
-  default: ccs
-  allowed: [ 'type 1', 'type 2', 'ccs', 'chademo' ]
+  default: 'CCS'
+  allowed: ['TYPE_1', 'TYPE_2', 'CCS', 'CHADEMO']
   description: Type of charge plug available on the vehicle (CSS includes Type2).
 
 Charging.Mode:
   datatype: string
   type: actuator
-  allowed: [ 'manual', 'timer', 'grid' ]
+  allowed: ['MANUAL', 'TIMER', 'GRID']
   description: Control of the charge process - manually initiated (plug-in event, companion app, etc), timer-based or grid-controlled (eg ISO 15118).
 
 Charging.IsCharging:
@@ -153,7 +153,7 @@ Charging.IsCharging:
 Charging.StartStopCharging:
   datatype: string
   type: actuator
-  allowed: [ 'start', 'stop' ]
+  allowed: ['START', 'STOP']
   description: Start or stop the charging process.
 
 Charging.ChargeCurrent:
@@ -191,11 +191,11 @@ Charging.Timer:
 Charging.Timer.Mode:
   datatype: string
   type: actuator
-  allowed: [ 'inactive', 'starttime', 'endtime' ]
+  allowed: ['INACTIVE', 'START_TIME', 'END_TIME']
   description: "Defines timer mode for charging:
-               'inactive' - no timer set, charging may start as soon as battery is connected to a charger.
-               'starttime' - charging shall start at Charging.Timer.Time.
-               'endtime' - charging shall be finished (reach StateOfCharge.Target) at Charging.Timer.Time.
+               INACTIVE - no timer set, charging may start as soon as battery is connected to a charger.
+               START_TIME - charging shall start at Charging.Timer.Time.
+               END_TIME - charging shall be finished (reach StateOfCharge.Target) at Charging.Timer.Time.
                When charging is completed the vehicle shall change mode to 'inactive' or set a new Charging.Timer.Time.
                Charging shall start immediately if mode is 'starttime' or 'endtime' and Charging.Timer.Time is a time in the past."
 

--- a/spec/Powertrain/CombustionEngine.vspec
+++ b/spec/Powertrain/CombustionEngine.vspec
@@ -39,10 +39,10 @@ Bore:
 Configuration:
   datatype: string
   type: attribute
-  allowed: [ "unknown", "straight", "V", "boxer", "W",
-        "rotary", "radial", "square", "H", "U", "opposed", "X" ]
+  allowed: ['UNKNOWN', 'STRAIGHT', 'V', 'BOXER', 'W',
+        'ROTARY', 'RADIAL', 'SQUARE', 'H', 'U', 'OPPOSED', 'X']
   description: Engine configuration.
-  default: "unknown"
+  default: 'UNKNOWN'
 
 NumberOfCylinders:
   datatype: uint16
@@ -88,26 +88,26 @@ MaxTorque:
 AspirationType:
   datatype: string
   type: attribute
-  allowed: [ "unknown", "natural", "supercharger", "turbocharger" ]
-  default: "unknown"
+  allowed: ['UNKNOWN', 'NATURAL', 'SUPERCHARGER', 'TURBOCHARGER']
+  default: 'UNKNOWN'
   description: Type of aspiration (natural, turbocharger, supercharger etc).
 
 FuelType:
   datatype: string
   type: attribute
-  allowed: [ "unknown", "gasoline", "diesel", "E85", "CNG" ]
-  default: "unknown"
+  allowed: ['UNKNOWN', 'GASOLINE', 'DIESEL', 'E85', 'CNG']
+  default: 'UNKNOWN'
   description: Type of fuel that the engine runs on.
 
 EngineOilLevel:
   datatype: string
   type: sensor
   allowed: [ 
-    "critically_low",  # Critically low, immediate action required
-    "low",             # Level below recommended range, but not critical
-    "normal",          # Within normal range, no need for driver action
-    "high",            # Level above recommended range, but not critical
-    "critically_high"  # Critically high, immediate action required
+    'CRITICALLY_LOW',  # Critically low, immediate action required
+    'LOW',             # Level below recommended range, but not critical
+    'NORMAL',          # Within normal range, no need for driver action
+    'HIGH',            # Level above recommended range, but not critical
+    'CRITICALLY_HIGH'  # Critically high, immediate action required
     ]
   description: Engine oil level.
 

--- a/spec/Powertrain/FuelSystem.vspec
+++ b/spec/Powertrain/FuelSystem.vspec
@@ -13,15 +13,15 @@
 FuelType:
   datatype: string
   type: attribute
-  allowed: [ "unknown", "gasoline", "diesel", "electric", "hybrid", "E85", "CNG", "LPG" ]
-  default: "unknown"
+  allowed: ['UNKNOWN', 'GASOLINE', 'DIESEL', 'ELECTRIC', 'HYBRID', 'E85', 'CNG', 'LPG']
+  default: 'UNKNOWN'
   description: Defines the fuel type of the vehicle.
 
 HybridType:
   datatype: string
   type: attribute
-  allowed: [ "unknown", "not_applicable", "stop_start", "belt_ISG", "CIMG", "PHEV" ]
-  default: "unknown"
+  allowed: ['UNKNOWN', 'NOT_APPLICABLE', 'STOP_START', 'BELT_ISG', 'CIMG', 'PHEV']
+  default: 'UNKNOWN'
   description: Defines the hybrid type of the vehicle.
 
 TankCapacity:

--- a/spec/Powertrain/Transmission.vspec
+++ b/spec/Powertrain/Transmission.vspec
@@ -17,8 +17,8 @@
 Type:
   datatype: string
   type: attribute
-  allowed: [ "unknown", "sequential", "H", "automatic", "DSG", "CVT" ]
-  default: "unknown"
+  allowed: ['UNKNOWN', 'SEQUENTIAL', 'H', 'AUTOMATIC', 'DSG', 'CVT']
+  default: 'UNKNOWN'
   description: Transmission type.
 
 
@@ -31,8 +31,8 @@ GearCount:
 DriveType:
   datatype: string
   type: attribute
-  allowed: [ "unknown", "forward wheel drive", "rear wheel drive", "all wheel drive" ]
-  default: "unknown"
+  allowed: ['UNKNOWN', 'FORWARD_WHEEL_DRIVE', 'REAR_WHEEL_DRIVE', 'ALL_WHEEL_DRIVE']
+  default: 'UNKNOWN'
   description: Drive type.
 
 
@@ -93,7 +93,7 @@ IsElectricalPowertrainEngaged:
 PerformanceMode:
   datatype: string
   type: actuator
-  allowed: [ "normal", "sport", "economy", "snow", "rain" ]
+  allowed: ['NORMAL', 'SPORT', 'ECONOMY', 'SNOW', 'RAIN']
   description: Current gearbox performance mode.
 
 
@@ -103,7 +103,7 @@ PerformanceMode:
 GearChangeMode:
   datatype: string
   type: actuator
-  allowed: [ "manual", "automatic" ]
+  allowed: ['MANUAL', 'AUTOMATIC']
   description: Is the gearbox in automatic or manual (paddle) mode.
 
 

--- a/spec/Vehicle/Vehicle.vspec
+++ b/spec/Vehicle/Vehicle.vspec
@@ -40,7 +40,7 @@ VersionVSS.Patch:
 VersionVSS.Label:
   datatype: string
   type: attribute
-  default: "develop"
+  default: 'develop'
   description: Label to further describe the version.
 
 #
@@ -157,12 +157,12 @@ LowVoltageSystemState:
   datatype: string
   type: sensor
   allowed: [
-    "UNDEFINED", # State of low voltage system not known
-    "LOCK",      # Low voltage system off, steering lock or equivalent engaged
-    "OFF",       # Low voltage system off, steering lock or equivalent not engaged
-    "ACC",       # Vehicle Accessories on/living
-    "ON",        # Engine start enabled (e.g. ignition on, diesel pre-heating, electrical drive released)
-    "START"      # Engine starter relay closed (not applicable for electrical vehicles)
+    'UNDEFINED', # State of low voltage system not known
+    'LOCK',      # Low voltage system off, steering lock or equivalent engaged
+    'OFF',       # Low voltage system off, steering lock or equivalent not engaged
+    'ACC',       # Vehicle Accessories on/living
+    'ON',        # Engine start enabled (e.g. ignition on, diesel pre-heating, electrical drive released)
+    'START'      # Engine starter relay closed (not applicable for electrical vehicles)
     ]
   description: State of the supply voltage of the control units (usually 12V).
 


### PR DESCRIPTION
This is an attempt to harmonize the use of literals for "allowed" values in the VSS standard, so that they as default use only uppercase, number and underscore. That has in this PR been consistently changed, but there might be some cases where it can be discussed if the recommendation shall be followed or not.

In most cases the change is straight forward, but for some a bit more advanced "translation" has been proposed, e.g. replacing `kWh/100mi` with `KILOWATT_HOURS_PER_100_MILES`.

This PR has not analyzed if the values/signals actually make sense, i.e. no values have been added/removed, the semantic meaning of each is supposed to be the same after the rename. Also `UNKNOWN` is kept as is, it need to be discussed on signal by signal basis whether it makes sense to keep it or not.


Notes:

Private-branch (CARFIT) not updated - private branch so not covered by recommendations. Branches reflecting other standards/solutions might also be a typical case where it might be a reason not to follow the recommendation. If e.g. CARFIT use `abc`, then it might be less useful to require that it shall be `ABC` in VSS.