### PR TITLE
Adding attributes for engine code

### DIFF
--- a/spec/Powertrain/CombustionEngine.vspec
+++ b/spec/Powertrain/CombustionEngine.vspec
@@ -1,7 +1,7 @@
 #
+# (C) 2020 Robert Bosch GmbH
 # (C) 2018 Volvo Cars
 # (C) 2016 Jaguar Land Rover
-# (C) 2020 Robert Bosch GmbH
 #
 # All files and artifacts in this repository are licensed under the
 # provisions of the license provided by the LICENSE file in this repository.
@@ -17,6 +17,13 @@
 #
 # Engine attributes
 #
+
+EngineCode:
+  datatype: string
+  type: attribute
+  description: Engine code designation, as specified by vehicle manufacturer.
+  comment: For hybrid vehicles the engine code may refer to the combination of
+           combustion and electric engine.
 
 Displacement:
   datatype: uint16

--- a/spec/Powertrain/ElectricMotor.vspec
+++ b/spec/Powertrain/ElectricMotor.vspec
@@ -10,6 +10,10 @@
 # EV Motor signals and attributes
 #
 
+EngineCode:
+  datatype: string
+  type: attribute
+  description: Engine code designation, as specified by vehicle manufacturer.
 
 MaxPower:
   datatype: uint16


### PR DESCRIPTION
Knowing what type of engine(s) the vehicle is equipped with is
important information for garages. This PR introduces two signals
for engine codes, one for combustion engines and one for electric
engines.

For hybrid vehicles a manufacturer might use a common designation
for the whole drivetrain rather than separate engine codes.
I.e. the engine code for combustion engine may include
information also on the electric motors used.

Signed-off-by: Erik Jaegervall <erik.jaegervall@se.bosch.com>