### PR TITLE
Add support for frunks

### DIFF
--- a/spec/Body/Body.vspec
+++ b/spec/Body/Body.vspec
@@ -38,6 +38,7 @@ Hood.IsOpen:
 #
 Trunk:
   type: branch
+  instances: ["Front", "Rear"]
   description: Trunk status.
 
 Trunk.IsOpen:


### PR DESCRIPTION
Will solve #391 

As "frunk" seems colloquial, I went  with instances for "Front" and "Rear", this is also aligned with wording in .
 Tesla manual:  "Front trunk" and "Rear trunk" ("vorderer Kofferraum", "hinterer Kofferraum" in German)  https://www.tesla.com/ownersmanual/model3/en_us/
or KIA (EV6) says "Front trunk"   https://gimmemanuals.com/owners/2022/03/2022-kia-ev6-owners-manual.pdf

Ford Mach E  says "Kofferraum vorn" but "front luggage compartment"
https://www.fordservicecontent.com/Ford_Content/Catalog/owner_information/2021-Ford-Mustang-Mach-E-Owners-Manual-version-1_om_DE_09_2020.pdf
https://www.fordservicecontent.com/Ford_Content/Catalog/owner_information/2021-Ford-Mustang-Mach-E-Owners-Manual-Job-2_version-1_om_EN-US_05_2021.pdf


There deviations, e.g. Porsche: Bonnet and tailgate/rear lid https://www.taycanforum.com/forum/attachments/2020-porsche-taycan-drivers-owners-manual-pdf.3634/?hash=f1054d844b404c69dc097ac2448c927a , or Audi eTron is also in the   "luggage compartment" compartment"

However I feel front/rear trunk captures the meaning of two storage areas well.

Independent from that, we might want to model "Bonnet", as in "cover for access to the engine", as we do not have that, but I would consider that another PR
