### PR TITLE
Clarifying meaning of allowed for arrays

### DIFF
--- a/docs-gen/content/rule_set/data_entry/allowed.md
+++ b/docs-gen/content/rule_set/data_entry/allowed.md
@@ -4,6 +4,7 @@ date: 2019-08-04T12:37:12+02:00
 weight: 5
 ---
 
+## Specifying allowed values
 Optionally it is possible to define an array of `allowed` values, which will restrict the usage of the data entry in the implementation of the specification.
 It is expected, that any value not mentioned in the array is considered an error and the implementation of the specification shall react accordingly.
 The datatype of the array elements is the `datatype` defined for the data entry itself.
@@ -28,6 +29,8 @@ specified in this list.
 The `datatype` specifier gives the type of the individual elements of the `allowed`
 list.
 
+## Recommendation on String values
+
 For string values used for `default` and `allowed` statements it is recommended to start with `A-Z`
 and then use only `A-Z`, `0-9` and underscore (`_`).
 It is recommended to use single quotes (`'`) as tooling otherwise might handle literals like `OFF` as boolean values with unexpected result.
@@ -35,3 +38,34 @@ It is recommended not to specify a dedicated value corresponding to "unknown" or
 The background is that a signal with an array of allowed values shall be handled just as any other signal.
 If e.g. the value of current speed or vehicle weight is unknown, then the vehicle shall not publish the corresponding signal.
 Similarly, for the example above, if the steering wheel position is unknown then `SteeringWheel.Position`shall not be published.
+
+## Allowed values for array types
+
+The `allowed` keyword can also be used for signals of array type. In that case, `allowed` specifies the only valid values for array elements.
+The actual value of the signal is expected to contain a subset of the values specified in `allowed`.
+
+Example:
+
+```YAML
+FavoriteColors:
+  datatype: string[]
+  type: attribute
+  allowed: ['RED', 'GREEN', 'BLUE', 'YELLOW', 'BROWN']
+  description: Driver's favorite colors.
+```
+
+Examples of valid arrays:
+
+```
+  [] # Empty array
+  ['RED']
+  ['YELLOW', 'BROWN', 'RED', 'GREEN', 'BLUE']
+  ['BLUE', 'BLUE'] # duplication is allowed
+```
+
+
+Example of an invalid array:
+
+```
+  ['RED', 'BLUE', 'BLACK'] # BLACK is not an allowed value
+```


### PR DESCRIPTION
As discussed in a previous meeting. If specifying `allowed` for a signal of array type, the `allowed` declaration specifies individual elements to be used in the array, rather than specifying exactly how the array must look like