### PR TITLE
Adding signal for vehicle broken down status.

### DIFF
--- a/spec/Vehicle/Vehicle.vspec
+++ b/spec/Vehicle/Vehicle.vspec
@@ -185,6 +185,15 @@ TripMeterReading:
   unit: km
   description: Current trip meter reading.
 
+IsBrokenDown:
+  datatype: boolean
+  type: sensor
+  description: Vehicle breakdown or any similar event causing vehicle to stop on the road,
+               that might pose a risk to other road users.
+               True = Vehicle broken down on the road, due to e.g. engine problems, flat tire, out of gas, brake problems.
+               False = Vehicle not broken down.
+  comment: Actual criteria and method used to decide if a vehicle is broken down is implementation specific.
+
 IsMoving:
   datatype: boolean
   type: sensor


### PR DESCRIPTION
Intention is to cover scenarios where vehicle is "broken down", e.g. it is not possible
to drive the car, it is not safe to drive the car or the car can be further damaged.

Signal description based on Sensoris Hazard.TypeAndConfidence.Type

See https://sensoris.org/wp-content/uploads/sites/21/2021/09/sensoris-specification-v1.2.2-public-1.zip