### PR TITLE
Introducing signal for connectivity available

### DIFF
--- a/spec/Vehicle/Connectivity.vspec
+++ b/spec/Vehicle/Connectivity.vspec
@@ -1,0 +1,23 @@
+#
+# (C) 2022 Robert Bosch GmbH
+#
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
+#
+#
+# Connectivity data
+#
+# This file contains signals related to connectivity between Vehicle and X (V2X).
+# Initially it contains only a single signal specifying if connectivity available.
+# May later be extended with information on type of connectivity available (e.g., Wi-Fi, Cellular), signal strength,
+# and throughput.
+#
+
+IsConnectivityAvailable:
+  datatype: boolean
+  type: sensor
+  description: Indicates if connectivity between vehicle and cloud is available.
+               True = Connectivity is available. False = Connectivity is not available.
+  comment: This signal can be used by onboard vehicle services to decide what features that
+           shall be offered to the driver, for example disable the 'check for update' button if vehicle does
+           not have connectivity.

--- a/spec/VehicleSignalSpecification.vspec
+++ b/spec/VehicleSignalSpecification.vspec
@@ -191,3 +191,11 @@ Vehicle.Service:
   description: Service data.
 
 #include Vehicle/Service.vspec Vehicle.Service
+#
+# Connectivity information
+#
+Vehicle.Connectivity:
+  type: branch
+  description: Connectivity data.
+
+#include Vehicle/Connectivity.vspec Vehicle.Connectivity


### PR DESCRIPTION
A possible use-case for this signal is onboard services that relies on connectivity, like FOTA and possibly navigation. A service may check the `IsConnectivityAvailable` signal before e.g. enabling the button offering the user to download new maps or check for updates.

I assume implementation will vary. Some vehicles may only check if WiFi or Cellular connection is connected or even only available, others may more or less frequently check that also important destinations can be reached (e.g. OEM-cloud, maps-server, FOTA-server). Possibly additional signals might need to be added in the future, if e.g. a service only wants to offer certain services when WiFi (or other high speed or low cost connection) is available.