### PR TITLE
Aligning signals using percent

### DIFF
--- a/spec/Body/Body.vspec
+++ b/spec/Body/Body.vspec
@@ -76,6 +76,7 @@ Raindetection.Intensity:
   datatype: uint8
   type: sensor
   unit: percent
+  max: 100
   description: Rain intensity. 0 = Dry, No Rain. 100 = Covered.
 
 
@@ -114,6 +115,7 @@ Windshield.WasherFluid.IsLevelLow:
 Windshield.WasherFluid.Level:
   datatype: uint8
   unit: percent
+  max: 100
   type: sensor
   description: Washer fluid level as a percent. 0 = Empty. 100 = Full.
 

--- a/spec/Body/ExteriorMirrors.vspec
+++ b/spec/Body/ExteriorMirrors.vspec
@@ -13,6 +13,8 @@
 Tilt:
   datatype: int8
   unit: percent
+  min: -100
+  max: 100
   type: actuator
   description: Mirror tilt as a percent. 0 = Center Position. 100 = Fully Upward Position. -100 = Fully Downward Position.
 
@@ -20,6 +22,8 @@ Pan:
   datatype: int8
   type: actuator
   unit: percent
+  min: -100
+  max: 100
   description: Mirror pan as a percent. 0 = Center Position. 100 = Fully Left Position. -100 = Fully Right Position.
 
 IsHeatingOn:

--- a/spec/Cabin/Cabin.vspec
+++ b/spec/Cabin/Cabin.vspec
@@ -79,6 +79,7 @@ RearviewMirror.DimmingLevel:
   datatype: uint8
   type: actuator
   unit: percent
+  max: 100
   description: Dimming level of rearview mirror. 0 = undimmed. 100 = fully dimmed.
 
 

--- a/spec/Chassis/Wheel.vspec
+++ b/spec/Chassis/Wheel.vspec
@@ -17,6 +17,7 @@ Brake.FluidLevel:
   datatype: uint8
   type: sensor
   unit: percent
+  max: 100
   description: Brake fluid level as percent. 0 = Empty. 100 = Full.
 
 Brake.IsFluidLevelLow:
@@ -27,6 +28,8 @@ Brake.IsFluidLevelLow:
 Brake.PadWear:
   datatype: uint8
   type: sensor
+  unit: percent
+  max: 100
   description: Brake pad wear as percent. 0 = No Wear. 100 = Worn.
 
 Brake.IsBrakesWorn:

--- a/spec/Driver/Driver.vspec
+++ b/spec/Driver/Driver.vspec
@@ -15,6 +15,8 @@ DistractionLevel:
   datatype: float
   type: sensor
   unit: percent
+  min: 0
+  max: 100
   description: Distraction level of the driver will be the level how much the driver is distracted, by multiple factors. E.g. Driving situation, acustical or optical signales inside the cockpit, phone calls.
 
 IsEyesOnRoad:
@@ -26,12 +28,16 @@ AttentiveProbability:
   datatype: float
   type: sensor
   unit: percent
+  min: 0
+  max: 100
   description: Probability of attentiveness of the driver.
 
 FatigueLevel:
   datatype: float
   type: sensor
   unit: percent
+  min: 0
+  max: 100
   description: Fatigueness level of driver. Evaluated by multiple factors like trip time, behaviour of steering, eye status.
 
 HeartRate:


### PR DESCRIPTION
- Added max:100 (if not already where) for signals where I assume logical max value shall be 100
- Added min:0 (if not already where) for signals where I assume logical min value shall be 0
  (Exception is unsigned data types, where minimum value 0 is given implicitly)
- Added "percent" as data unit type in one case where it was missing
- (Exception: Did not update the OBD signals, bigger effort to check actual limits specified in OBD standard)