### PR TITLE
Changed Electric Engine Rpm to Speed

### DIFF
--- a/spec/Powertrain/ElectricMotor.vspec
+++ b/spec/Powertrain/ElectricMotor.vspec
@@ -46,7 +46,7 @@ MaxRegenTorque:
 #
 # Motor rotations per minute
 #
-Rpm:
+Speed:
   datatype: int32
   type: sensor
   unit: rpm


### PR DESCRIPTION
Speed is cositently used as name, whereas rpm
is used as unit. Applied this logic to electric
engine as well.

fixes: #440

Signed-off-by: Daniel Wilms <Daniel.DW.Wilms@bmw.de>