### PR TITLE
Adding support for multiple wiper systems as a layer

### DIFF
--- a/overlays/README.md
+++ b/overlays/README.md
@@ -1,0 +1,12 @@
+# OVERLAYS
+
+This directory contains overlays for VSS. Use of overlays is a new concept for VSS.
+The overlays in this folder shall currently be seen as examples only, and are not part of the official VSS specification.
+
+## Profiles 
+
+Larger overlays to adapt VSS to a specific vehicle category, like motorbikes.
+
+## Extensions
+
+Smaller overlays typically to be applied after applying profiles (if any).

--- a/overlays/extensions/dual_wiper_systems.vspec
+++ b/overlays/extensions/dual_wiper_systems.vspec
@@ -1,0 +1,33 @@
+#
+# (C) 2022 Robert Bosch GmbH
+#
+# Overlay to extend wiper system to support multiple instances
+# Dependencies to other overlays: None
+# Known conflicts with other overlays: None
+#
+Vehicle:
+  type: branch
+
+Vehicle.Body:
+  type: branch
+  description: All body components.
+
+Vehicle.Body.Windshield:
+  type: branch
+  instances: ["Front", "Rear"]
+  description: Windshield signals.
+  
+Vehicle.Body.Windshield.Wiping:
+  type: branch
+  description: Windshield wiper signals.
+
+# Standard VSS does not specify instances
+# This overlay specifies two instances, Primary and Secondary
+
+Vehicle.Body.Windshield.Wiping.System:
+  type: branch
+  instances: [Primary, Secondary]
+  description: Signals to control behavior of wipers in detail.
+  comment:     These signals are typically not directly available to the user/driver of the vehicle.
+               Primary refers to the primary wiper system for the windshield.
+               Secondary refers to the secondary wiper system for the same windshield.

--- a/spec/Body/Body.vspec
+++ b/spec/Body/Body.vspec
@@ -112,15 +112,11 @@ Windshield.Wiping.Intensity:
 
 Windshield.Wiping.System:
   type: branch
-#  instances: [Primary, Secondary]
   description: Signals to control behavior of wipers in detail.
                By default VSS expects only one instance.
   comment:     These signals are typically not directly available to the user/driver of the vehicle.
-               A vehicle may have multiple mechanically disconnected wiper systems serving the same windshield.
-               If that is the case for a vehicle it is recommended to add
-               instance declarations for Primary and Secondary, possibly in a layer.
-               Primary then refers to the primary wiper system for the windshield.
-               Secondary then refers to the secondary wiper system for the same windshield.
+               The overlay in overlays/extensions/dual_wiper_systems.vspec can be used to modify this branch
+               to support two instances; Primary and Secondary.
 
 #include WiperSystem.vspec Windshield.Wiping.System
 


### PR DESCRIPTION
This is a follow up of the latest changes introduced by #431. There we agreed that standard VSS by default should not contain multiple wiper systems (for a single window) as that is still unusual.  If needed the instances can be created by an overlay. This PR provides a possible overlay. 

I think this one together with #450 can be used as a starting point of how how we want to store/structure overlays in VSS. I am thinking if it would make sense to categorize them, possibly like:

- Profiles - larger overlays to adapt VSS to a specific vehicle category, like motorbikes. Tested by VSS CI and maintained by community.
- Extensions - Smaller changes typically to be applied after applying profiles. Tested by VSS CI and maintained by community.
- Contrib - Contributed changes (profiles or extensions). Not necessarily tested by VSS CI. VSS may be released even if some contrib overlays are non-functional.

With this approach "Contrib" could also be used for profiles/extensions that not yet are sufficiently stable or mature.

Use this layer like this:

```
erik@debian2:~/vehicle_signal_specification$ ./vss-tools/vspec2csv.py -I ./spec -o layers/extensions/dual_wiper_systems.vspec ./spec/VehicleSignalSpecification.vspec vss_rel_$(cat VERSION).csv
Output to csv format
Loading vspec from ./spec/VehicleSignalSpecification.vspec...
Applying VSS overlay from layers/extensions/dual_wiper_systems.vspec...
Calling exporter...
Generating CSV output...
All done.
```
