### PR TITLE
Add tar-file command to Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,4 @@
 *.id
 
 # Generated files
-vss_rel_*.cnative
-vss_rel_*.csv
-vss_rel_*.fidl
-vss_rel_*.binary
-vss_rel_*.h
-vss_rel_*.json
-vss_rel_*_macro.h
+vss_rel_*

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,13 @@
 # Makefile to generate specifications
 #
 
-.PHONY: clean all travis_targets json franca yaml csv ddsidl tests binary protobuf ttl graphql ocf c install deploy
+.PHONY: clean all travis_targets json franca yaml csv ddsidl tests binary protobuf ttl graphql ocf c install
 
 all: clean json franca yaml csv ddsidl binary tests protobuf graphql
 
 # All mandatory targets that shall be built and pass on each pull request for
 # vehicle-signal-specification or vss-tools
-travis_targets: clean json franca yaml binary csv graphql ddsidl tests deploy
+travis_targets: clean json franca yaml binary csv graphql ddsidl tests tar
 
 
 # Additional targets that shall be built by travis, but where it is not mandatory
@@ -21,8 +21,6 @@ travis_optional: clean c ocf protobuf ttl
 
 DESTDIR?=/usr/local
 TOOLSDIR?=./vss-tools
-DEPLOYDIR?=./docs-gen/static/releases/nightly
-
 
 json:
 	${TOOLSDIR}/vspec2json.py -I ./spec ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).json
@@ -62,6 +60,12 @@ c:
 	(cd ${TOOLSDIR}/contrib/vspec2c/; make )
 	PYTHONPATH=${TOOLSDIR} ${TOOLSDIR}/contrib/vspec2c.py -I ./spec ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).h vss_rel_$$(cat VERSION)_macro.h
 
+# Include all offically supported outputs (i.e. those created by travis_targets)
+# Exception is binary as it might be target specific and library anyway needs to be rebuilt
+tar:
+	tar -czvf vss_rel_$$(cat VERSION).tar.gz vss_rel_$$(cat VERSION).json vss_rel_$$(cat VERSION).fidl vss_rel_$$(cat VERSION).yaml \
+	vss_rel_$$(cat VERSION).csv vss_rel_$$(cat VERSION).graphql.ts vss_rel_$$(cat VERSION).idl
+
 clean:
 	rm -f vss_rel_*
 	(cd ${TOOLSDIR}/contrib/vspec2c/; make clean)
@@ -73,11 +77,3 @@ install:
 	$(MAKE) DESTDIR=${DESTDIR} -C ${TOOLSDIR}/vspec2c install
 	install -d ${DESTDIR}/share/vss
 	(cd spec; cp -r * ${DESTDIR}/share/vss)
-
-deploy:
-	if [ -d $(DEPLOYDIR) ]; then \
-	  rm -f ${DEPLOYDIR}/vss_rel_*;\
-	else \
-	  mkdir -p ${DEPLOYDIR}; \
-	fi;
-	cp  vss_rel_* ${DEPLOYDIR}/


### PR DESCRIPTION
Also remove obsolete deploy command and update gitignore

Background for this PR is to simplify our release process by having a "make tar" command that creates the *.tar.gz file attached to our releases. The intention (for now) is that the maintainer preparing the release manually will use the command as part of the release process. 