### PR TITLE
Improve trunk/hood documentation

### DIFF
--- a/spec/Body/Body.vspec
+++ b/spec/Body/Body.vspec
@@ -27,11 +27,15 @@ RefuelPosition:
 Hood:
   type: branch
   description: Hood status.
+  comment: The hood is the hinged cover over the engine compartment of a motor vehicles.
+           Depending on vehicle, it can be either in the front or back of the vehicle.
+           Luggage compartments are in VSS called trunks, even if they are located at the front of the vehicle.
 
 Hood.IsOpen:
   datatype: boolean
   type: actuator
   description: Hood open or closed. True = Open. False = Closed.
+
 
 #
 # Trunk description
@@ -40,6 +44,9 @@ Trunk:
   type: branch
   instances: ["Front", "Rear"]
   description: Trunk status.
+  comment: A trunk is a luggage compartment in a vehicle.
+           Depending on vehicle, it can be either in the front or back of the vehicle.
+           Some vehicles may have trunks both at the front and at the rear of the vehicle.
 
 Trunk.IsOpen:
   datatype: boolean


### PR DESCRIPTION
I got some internal questions on the difference between "front trunk" and "hood". This PR tries to improve the documentation based on the discussion we had when introducing front trunk.

Example: Is the luggage compartment at the front of a Porsche 911 considered to be a "hood" or "front trunk"? This comment tries to specify that it preferably shall be considered as "front trunk" rather than "hood" (as it gives access to a luggage compartment and not an engine compartment). 