### PR TITLE
Buildcheck update

### DIFF
--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -25,9 +25,13 @@ jobs:
           python -V
           python -m pip --quiet --no-input install --upgrade pip 
           python -m pip --quiet --no-input install --upgrade pipenv wheel
+          pipenv --version
+          pipenv run python --version
           cd vss-tools
-          pipenv install
-          pipenv run python setup.py -q install
+          
+          pipenv install --sequential
+          echo done!
+          pipenv run python setup.py install
         env:
           PIPENV_VENV_IN_PROJECT: 1
           


### PR DESCRIPTION
This seems at least for now to solve the build problems - have run it a few times without experiencing any problems. As the error occurred quite recently I expect that we have succeeded to find a spot where pipenv is not as deterministic as one would like. The use of the `--sequential flag` seems to help, but I am no pipenv expert, so there might be other reasons.

https://buildmedia.readthedocs.org/media/pdf/pipenv/stable/pipenv.pdf

_Installation is intended to be as deterministic as possible — use the `--sequential flag` to increase this, if experiencing issues._

Also improving verbosity on the part where the build have failed in the past.


Signed-off-by: Erik Jaegervall <erik.jaegervall@se.bosch.com>