### PR TITLE
Extend motorbike profile and include profiles in builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,13 @@
 # Makefile to generate specifications
 #
 
-.PHONY: clean all travis_targets json franca yaml csv ddsidl tests binary protobuf ttl graphql ocf c install
+.PHONY: clean all travis_targets json franca yaml csv ddsidl tests binary protobuf ttl graphql ocf c install overlays
 
-all: clean json franca yaml csv ddsidl binary tests protobuf graphql
+all: clean json franca yaml csv ddsidl binary tests protobuf graphql overlays
 
 # All mandatory targets that shall be built and pass on each pull request for
 # vehicle-signal-specification or vss-tools
-travis_targets: clean json franca yaml binary csv graphql ddsidl tests tar
+travis_targets: clean json franca yaml binary csv graphql ddsidl overlays tests tar
 
 
 # Additional targets that shall be built by travis, but where it is not mandatory
@@ -36,6 +36,11 @@ csv:
 
 ddsidl:
 	${TOOLSDIR}/vspec2ddsidl.py -I ./spec ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).idl
+
+# Verifies that supported overlay combinations are syntactically correct.
+overlays:
+	${TOOLSDIR}/vspec2json.py -I ./spec -o overlays/profiles/motorbike.vspec ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION)_motorbike.json
+	${TOOLSDIR}/vspec2json.py -I ./spec -o overlays/extensions/dual_wiper_systems.vspec ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION)_dualwiper.json
 
 tests:
 	PYTHONPATH=${TOOLSDIR} pytest

--- a/overlays/profiles/motorbike.vspec
+++ b/overlays/profiles/motorbike.vspec
@@ -1,5 +1,6 @@
 #
 # (C) 2022, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# (C) 2022 Robert Bosch GmbH
 #
 # All files and artifacts in this repository are licensed under the
 # provisions of the license provided by the LICENSE file in this repository.
@@ -43,3 +44,48 @@ Vehicle.Cabin.Handlebar.GripHeating:
   datatype: string
   allowed: ["HEATING_OFF", "HEATING_STEP_1", "HEATING_STEP_2", "HEATING_STEP_3", "HEATING_STEP_4", "HEATING_STEP_5", "HEATING_AUTOMATIC"]
   description: Grip Heating Status in motorbikes. The signal shows if the handlebar grip heating is on or not, and if yes, to which level.
+
+Vehicle.LeanAngle:
+    type: sensor
+    datatype: float
+    unit: degrees
+    description: Lean Angle of the Motorcycle in Y direction. 0 = upright, 
+                 positive = leaning right from rider perspective,
+                 negative = leaning left from rider perspective.
+
+Vehicle.IMU:
+    type: branch
+    description: Information related to the Inertial Measurement Unit to record angular rates and velocity-related information.
+
+Vehicle.IMU.IsOK:
+    type: sensor
+    datatype: boolean
+    description: Indicates if IMU is working. True = OK. False = Failure.
+
+Vehicle.ADAS:
+    type: branch
+
+# Motorbikes typically have different ABS-systems for front and rear wheel
+Vehicle.ADAS.ABS:
+    type: branch
+    instances: ["Front","Rear"]
+
+Vehicle.Powertrain:
+    type: branch
+
+Vehicle.Powertrain.Transmission:
+    type: branch
+
+Vehicle.Powertrain.Transmission.IsClutchSwitchOperated:
+    type: sensor
+    datatype: boolean
+    description: Indicates if the Clutch switch is operated, so engine and transmission are partially or fully decoupled. False = Clutch switch not operated. True = Clutch switch operated.
+
+Vehicle.Powertrain.CombustionEngine:
+    type: branch
+
+Vehicle.Powertrain.CombustionEngine.FuelInjectionQuantity:
+    type: sensor
+    datatype: float
+    unit: ml
+    description: Amount of injected Fuel in millilitres per cylinder per injection.


### PR DESCRIPTION
This PR contains some signals relevant to motorbikes.
Some of them might be of general interest and may be moved to
"standard vss" later.

Signed-off-by: Erik Jaegervall <erik.jaegervall@se.bosch.com>