### PR TITLE
Remove pipenv parameter sequential

### DIFF
--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -29,7 +29,7 @@ jobs:
           pipenv run python --version
           cd vss-tools
           
-          pipenv install --sequential
+          pipenv install
           echo done!
           pipenv run python setup.py install
         env:


### PR DESCRIPTION
This parameter was added to solve buildproblems some time ago. But now it has been removed and thus must be removed from our code as well Changed in pipenv v2022.9.20
https://github.com/pypa/pipenv/commit/a38d1538c5fc4a45c95c67452730eec887f0fea5