### PR TITLE
Enable proper search in generated documentation

### DIFF
--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -53,10 +53,10 @@ jobs:
 
       - name: Install hugo
         env:
-          HUGO_VER : 0.78.1
+          HUGO_VER : 0.103.1
         run: |
-          curl -LO https://github.com/gohugoio/hugo/releases/download/v${HUGO_VER}/hugo_${HUGO_VER}_Linux-64bit.deb
-          sudo dpkg -i hugo_${HUGO_VER}_Linux-64bit.deb
+          curl -LO https://github.com/gohugoio/hugo/releases/download/v${HUGO_VER}/hugo_${HUGO_VER}_linux-amd64.deb
+          sudo dpkg -i hugo_${HUGO_VER}_linux-amd64.deb
 
       - name: Make docs
         run: |

--- a/docs-gen/README.md
+++ b/docs-gen/README.md
@@ -13,8 +13,9 @@ The static page is generated with:
 - [HUGO](https://gohugo.io/)
 - [Learn Theme](https://themes.gohugo.io/hugo-theme-learn/)
 
-Please follow the [documentation](https://gohugo.io/documentation/) for
-installation and further questions around the framework. Currently, the minimal tested HUGO version for the VSS documentation is `0.78.1`
+Please follow the [documentation](https://gohugo.io/documentation/) for installation and further questions around the framework.
+Currently, the HUGO version used for generating VSS documentation is `0.103.1`,
+as controlled by the [buildcheck.yml](https://github.com/COVESA/vehicle_signal_specification/blob/master/.github/workflows/buildcheck.yml)
 
 
 ### Run the documentation server locally
@@ -49,8 +50,7 @@ page under http://localhost:1313/vehicle_signal_specification.
 
 ### Contribute
 
-Right now there is no pipeline in place to build the documentation. If you want
-to contribute, do the following:
+If you want to contribute, do the following:
 
 1. **Change documentation in ```/docs-gen```**
 

--- a/docs-gen/config.toml
+++ b/docs-gen/config.toml
@@ -21,3 +21,7 @@ weight = 10
 name = "<i class='fas fa-download'></i> Releases"
 url = "https://github.com/covesa/vehicle_signal_specification/releases"
 weight = 12
+
+# Generation of JSON index to allow search
+[outputs]
+home = [ "HTML", "RSS", "JSON"]


### PR DESCRIPTION
Previously we did not generate the JSON index required, resulting in that only search on current page was enabled. 
Now enabling search as described [here](https://github.com/matcornic/hugo-theme-learn/blob/6cfd61e0f675b45ba85f8325e206d23a4337a14c/exampleSite/content/basics/configuration/_index.en.md#activate-search)

Also bumping hugo version.
Local test succesful.

Signed-off-by: Erik Jaegervall <erik.jaegervall@se.bosch.com>