### PR TITLE
Add SmartphoneMirroring into HMI branch

### DIFF
--- a/spec/Cabin/Infotainment.vspec
+++ b/spec/Cabin/Infotainment.vspec
@@ -157,7 +157,8 @@ SmartphoneProjection.Source:
   allowed: ['USB', 'BLUETOOTH', 'WIFI']
   description: Connectivity source selected for projection.
 
-SmartphoneProjection.List:
+SmartphoneProjection.SupportedMode:
   datatype: string[]
   type: sensor
+  allowed: [ 'ANDROID_AUTO', 'APPLE_CARPLAY', 'MIRROR_LINK', 'OTHER' ]
   description: Supportable list for projection.

--- a/spec/Cabin/Infotainment.vspec
+++ b/spec/Cabin/Infotainment.vspec
@@ -150,6 +150,7 @@ SmartphoneProjection.Active:
   type: actuator
   allowed: [ 'NONE', 'ACTIVE',  'INACTIVE' ]
   description: Projection activation info.
+  comment: NONE indicates that projection is not supported.
   
 SmartphoneProjection.Source:
   datatype: string
@@ -159,6 +160,6 @@ SmartphoneProjection.Source:
 
 SmartphoneProjection.SupportedMode:
   datatype: string[]
-  type: sensor
+  type: attribute
   allowed: [ 'ANDROID_AUTO', 'APPLE_CARPLAY', 'MIRROR_LINK', 'OTHER' ]
   description: Supportable list for projection.

--- a/spec/Cabin/Infotainment.vspec
+++ b/spec/Cabin/Infotainment.vspec
@@ -142,7 +142,7 @@ HMI.DayNightMode:
   description: Current display theme
   
 HMI.SmartphoneMirroring:
-	datatype: string
-	type: sensor
-	allowed: [ 'AndoridAuto', 'AppleCarplay', 'MirrorLink', 'UNKNOWN' ]
-	description: Mirroring info for connectivity of user's smartphone
+  datatype: string
+  type: sensor
+  allowed: [ 'AndoridAuto', 'AppleCarplay', 'MirrorLink', 'UNKNOWN' ]
+  description: Mirroring info for connectivity of user's smartphone

--- a/spec/Cabin/Infotainment.vspec
+++ b/spec/Cabin/Infotainment.vspec
@@ -140,3 +140,9 @@ HMI.DayNightMode:
   type: actuator
   allowed: ['DAY', 'NIGHT']
   description: Current display theme
+  
+HMI.SmartphoneMirroring:
+	datatype: string
+	type: sensor
+	allowed: [ 'AndoridAuto', 'AppleCarplay', 'MirrorLink', 'UNKNOWN' ]
+	description: Mirroring info for connectivity of user's smartphone

--- a/spec/Cabin/Infotainment.vspec
+++ b/spec/Cabin/Infotainment.vspec
@@ -141,8 +141,23 @@ HMI.DayNightMode:
   allowed: ['DAY', 'NIGHT']
   description: Current display theme
   
-HMI.SmartphoneMirroring:
+SmartphoneProjection:
+  type: branch
+  description: All smartphone projection actions.
+  
+SmartphoneProjection.Active:
   datatype: string
+  type: actuator
+  allowed: [ 'NONE', 'ACTIVE',  'INACTIVE' ]
+  description: Projection activation info.
+  
+SmartphoneProjection.Source:
+  datatype: string
+  type: actuator
+  allowed: ['USB', 'BLUETOOTH', 'WIFI']
+  description: Connectivity source selected for projection.
+
+SmartphoneProjection.List:
+  datatype: string[]
   type: sensor
-  allowed: [ 'AndoridAuto', 'AppleCarplay', 'MirrorLink', 'UNKNOWN' ]
-  description: Mirroring info for connectivity of user's smartphone
+  description: Supportable list for projection.


### PR DESCRIPTION
It is required to support SmartphoneMirroring into HMI branch.  Mirroring service such as AndroidAuto, AppleCarplay, and MirrorLink are broadly used in recent HMI system in the vehicle.  The connectivity information for smart device such as android or iOS based phone or tablet is required for VSS.