### PR TITLE
Add tire pressure unit to HMI

### DIFF
--- a/spec/Cabin/Infotainment.vspec
+++ b/spec/Cabin/Infotainment.vspec
@@ -138,7 +138,7 @@ HMI.TemperatureUnit:
 HMI.TirePressureUnit:
   datatype: string
   type: actuator
-  allowed: [‘psi’, ‘kPa’, ’bar’]
+  allowed: [‘PSI’, ‘KPA’, ’BAR’]
   description: Tire pressure unit used in the current HMI 
 
 HMI.DayNightMode:

--- a/spec/Cabin/Infotainment.vspec
+++ b/spec/Cabin/Infotainment.vspec
@@ -135,7 +135,7 @@ HMI.TemperatureUnit:
   allowed: ['C', 'F']
   description: Temperature unit used in the current HMI
  
-HMI.TirePressureUnit
+HMI.TirePressureUnit:
   datatype: string
   type: actuator
   allowed: [‘psi’, ‘kPa’, ’bar’]

--- a/spec/Cabin/Infotainment.vspec
+++ b/spec/Cabin/Infotainment.vspec
@@ -134,6 +134,12 @@ HMI.TemperatureUnit:
   type: actuator
   allowed: ['C', 'F']
   description: Temperature unit used in the current HMI
+ 
+HMI.TirePressureUnit
+  datatype: string
+  type: actuator
+  allowed: [‘psi’, ‘kPa’, ’bar’]
+  description: Tire pressure unit used in the current HMI 
 
 HMI.DayNightMode:
   datatype: string


### PR DESCRIPTION
- It needs to add tire pressure unit to HMI branch because there are three different units related with tire pressure in usual.