### PR TITLE
Add HMI signals

### DIFF
--- a/spec/Cabin/Infotainment.vspec
+++ b/spec/Cabin/Infotainment.vspec
@@ -140,6 +140,12 @@ HMI.DistanceUnit:
   allowed: ['MILES', 'KILOMETERS']
   description: Distance unit used in the current HMI
 
+HMI.FuelVolumeUnit:
+  datatype: string
+  type: actuator
+  allowed: ['LITER', 'GALLON_US', 'GALLON_UK']
+  description: Fuel volume unit used in the current HMI
+
 HMI.FuelEconomyUnits:
   datatype: string
   type: actuator
@@ -157,12 +163,25 @@ HMI.TemperatureUnit:
   type: actuator
   allowed: ['C', 'F']
   description: Temperature unit used in the current HMI
- 
+
 HMI.TirePressureUnit:
   datatype: string
   type: actuator
   allowed: [‘PSI’, ‘KPA’, ’BAR’]
   description: Tire pressure unit used in the current HMI 
+
+
+HMI.Brightness:
+  datatype: float
+  type: actuator
+  unit: percent
+  min: 0
+  max: 100
+  description: Brightness of the HMI, relative to supported range.
+               0 = Lowest brightness possible.
+               100 = Maximum Brightness possible.
+  comment: The value 0 does not necessarily correspond to a turned off HMI,
+           as it may not be allowed/supported to turn off the HMI completely.
 
 HMI.DayNightMode:
   datatype: string


### PR DESCRIPTION
Adds two HMI-related signals existing in Android HAL but not existing in VSS

FUEL_VOLUME_DISPLAY_UNITS
DISPLAY_BRIGHTNESS

Fixes #510 