### PR TITLE
Add light switches

### DIFF
--- a/spec/Body/Body.vspec
+++ b/spec/Body/Body.vspec
@@ -170,6 +170,26 @@ Lights:
   type: branch
   description: Exterior lights.
 
+Lights.LightSwitch:
+  datatype: string
+  type: actuator
+  allowed: ['OFF', 'POSITION', 'DAYTIME_RUNNING_LIGHTS', 'AUTO', 'BEAM']
+  description: Status of the vehicle main light switch.
+  comment: A vehicle typically does not support all alternatives.
+           Which lights that actually are lit may vary according to vehicle configuration and local legislation.
+           OFF is typically indicated by 0.
+           POSITION is typically indicated by ISO 7000 symbol 0456.
+           DAYTIME_RUNNING_LIGHTS (DRL) can be indicated by ISO 7000 symbol 2611.
+           AUTO indicates that vehicle automatically selects suitable lights.
+           BEAM is typically indicated by ISO 7000 symbol 0083.
+
+Lights.IsHighBeamSwitchOn:
+  datatype: boolean
+  type: actuator
+  description: Status of the high beam switch. True = high beam enabled. False = high beam not enabled.
+  comment: This signal indicates the status of the switch and does not indicate if low or high beam actually are on.
+           That typically depends on vehicle logic and other signals like Lights.LightSwitch and Vehicle.LowVoltageSystemState.
+
 Lights.Beam:
   type: branch
   instances: ["Low","High"]


### PR DESCRIPTION
VSS as of today has individual signals controlling/reporting if lights are on, but it does not have any signals representing the controls typically available to the driver. This PR intends to address that.

Some comments in addition to what is in the file

**Lights.LightSwitch**

- The "main" light switch that almost all vehicles have. 
- Actual behavior typically depends on ignition state and vehicle configuration. I.e. 'OFF' does not necessarily means that all lights are off, in countries where driving with lights off is illegal some vehicles will light tail light and low beam in 'OFF' mode, or some other configuration.
- Having an explicit DRL state seems to be rare, but exists. In many vehicles the only way to use DRL is to select AUTO and drive during daytime.

**Lights.IsHighBeamSwitchOn**

- The switch to enable high beam, on many vehicles controlled by the same handle as the blinkers
- I assume we do not need a "single flash" state, as that is handled by the handle mechanics rather than a special state
- I assume we do not need a separate signal or value for "automatic high beam" - on the cars I have driven so far the same switch is used and whether you get manual or automatic high beam depends on Lights.LightSwitch