### PR TITLE
Add steering angle

### DIFF
--- a/spec/Chassis/Chassis.vspec
+++ b/spec/Chassis/Chassis.vspec
@@ -60,7 +60,13 @@ Axle.WheelWidth:
   unit: inch
   description: Width of wheels (rims without tires), in inches, as per ETRTO / TRA standard.
 
-
+Axle.SteeringAngle:
+  datatype: float
+  type: sensor
+  unit: degrees
+  description: Single track two-axle model steering angle.
+               Angle according to ISO 8855. Positive = degrees to the left. Negative = degrees to the right.
+  comment: Single track two-axle model steering angle refers to the angle that a centrally mounted wheel would have.
 #
 # Tire attributes
 #


### PR DESCRIPTION
This adds steering angle for road wheels.

We already have angle for the steering wheel (Vehicle.Chassis.SteeringWheel.Angle) but until now we do not have any signal that represents actual angle for the road wheels. This PR adds a steering angle for each axle, to support vehicles that also has steering on rear axle, resulting in two new signals with default installation

```
Vehicle.Chassis.Axle.Row1.SteeringAngle
Vehicle.Chassis.Axle.Row2.SteeringAngle
```

Left and right wheel typically have different angles, the signal represents the angle that would be used if the axle instead had only one centrally mounted wheel. Here called "Single track two-axle model steering angle", other similar terms are "bicycle model steering angle".  Similar signals exist in for example Android VHAL as [PERF_STEERING_ANGLE](https://android.googlesource.com/platform/hardware/interfaces/+/master/automotive/vehicle/2.0/types.hal#398) and PERF_REAR_STEERING_ANGLE

Signed-off-by: Erik Jaegervall <erik.jaegervall@se.bosch.com>