### PR TITLE
Interior lights

### DIFF
--- a/spec/Body/Body.vspec
+++ b/spec/Body/Body.vspec
@@ -51,6 +51,12 @@ Trunk.IsLocked:
   type: actuator
   description: Is trunk locked or unlocked. True = Locked. False = Unlocked.
 
+Trunk.IsLightOn:
+  datatype: boolean
+  type: actuator
+  description: Is trunk light on
+  comment: V3.0 Moved from Vehicle.Cabin.Lights.IsTrunkOn
+
 
 #
 # Horn description

--- a/spec/Body/Body.vspec
+++ b/spec/Body/Body.vspec
@@ -1,5 +1,5 @@
 #
-# (C) 2023 BMW Group
+# (C) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 # (C) 2018 Volvo Cars
 # (C) 2016 Jaguar Land Rover
 #

--- a/spec/Body/Body.vspec
+++ b/spec/Body/Body.vspec
@@ -1,4 +1,5 @@
 #
+# (C) 2023 BMW Group
 # (C) 2018 Volvo Cars
 # (C) 2016 Jaguar Land Rover
 #

--- a/spec/Cabin/Cabin.vspec
+++ b/spec/Cabin/Cabin.vspec
@@ -89,30 +89,8 @@ RearviewMirror.DimmingLevel:
 Lights:
   type: branch
   description: Interior lights signals and sensors.
-
-# Include the lights specification and attach it under the Lights branch.x
 #include InteriorLights.vspec Lights
 
-#
-# Configurable lights
-#
-
-Lights.Spotlight:
-  type: branch
-  instances: 
-    - Row[1,4]
-    - ["Left","Shared","Right"]
-  description: Spotlight for a specific area in the vehicle.
-#include SingleConfigurableLight.vspec Lights.Spotlight
-
-
-Lights.AmbientLight:
-  type: branch
-  instances: 
-    - Row[1,2]
-    - ["Left","Right"]
-  description: Decorative coloured light inside the cabin, usually mounted on the door, cealing, etc.
-#include SingleConfigurableLight.vspec Lights.AmbientLight
 
 ##
 # Door signals and attributes

--- a/spec/Cabin/Cabin.vspec
+++ b/spec/Cabin/Cabin.vspec
@@ -97,22 +97,22 @@ Lights:
 # Configurable lights
 #
 
-Spotlight:
+Lights.Spotlight:
   type: branch
   instances: 
     - Row[1,4]
     - ["Left","Shared","Right"]
   description: Spotlight for a specific area in the vehicle.
-#include SingleConfigurableLight.vspec Spotlight
+#include SingleConfigurableLight.vspec Lights.Spotlight
 
 
-AmbientLight:
+Lights.AmbientLight:
   type: branch
   instances: 
     - Row[1,2]
     - ["Left","Right"]
   description: Decorative coloured light inside the cabin, usually mounted on the door, cealing, etc.
-#include SingleConfigurableLight.vspec AmbientLight
+#include SingleConfigurableLight.vspec Lights.AmbientLight
 
 ##
 # Door signals and attributes

--- a/spec/Cabin/Cabin.vspec
+++ b/spec/Cabin/Cabin.vspec
@@ -93,6 +93,27 @@ Lights:
 # Include the lights specification and attach it under the Lights branch.x
 #include InteriorLights.vspec Lights
 
+#
+# Configurable lights
+#
+
+Spotlight:
+  type: branch
+  instances: 
+    - Row[1,4]
+    - ["Left","Shared","Right"]
+  description: Spotlight for a specific area in the vehicle.
+#include SingleConfigurableLight.vspec Spotlight
+
+
+AmbientLight:
+  type: branch
+  instances: 
+    - Row[1,2]
+    - ["Left","Right"]
+  description: Decorative coloured light inside the cabin, usually mounted on the door, cealing, etc.
+#include SingleConfigurableLight.vspec AmbientLight
+
 ##
 # Door signals and attributes
 # The default VSS (i.e. this file) assumes a vehicle with two rows of doors

--- a/spec/Cabin/InteriorLights.vspec
+++ b/spec/Cabin/InteriorLights.vspec
@@ -1,4 +1,5 @@
 #
+# (C) 
 # (C) 2018 Volvo Cars
 # (C) 2016 Jaguar Land Rover
 #
@@ -10,6 +11,9 @@
 # All interior lights and sensors
 #
 
+#
+# Non-configurable lights
+#
 IsGloveBoxOn:
   datatype: boolean
   type: actuator
@@ -18,20 +22,22 @@ IsGloveBoxOn:
 IsTrunkOn:
   datatype: boolean
   type: actuator
-  description: Is trunk light light on
+  description: Is trunk light on
+  deprecation: V3.0 moved to Vehicle.Body.Trunk.isLightOn as the Trunk is not defined as part of the Cabin.
 
 IsDomeOn:
   datatype: boolean
   type: actuator
   description: Is central dome light light on
 
-AmbientLight:
+PerceivedAmbientLight:
   datatype: uint8
   type: sensor
   unit: percent
   min: 0
   max: 100
-  description: How much ambient light is detected in cabin. 0 = No ambient light. 100 = Full brightness
+  description: The percentage of ambient light that is measured (e.g., by a sensor) inside the cabin. 0 = No ambient light. 100 = Full brightness.
+  comment: See also Vehicle.Cabin.Lights.AmbientLight, which is used for acting on the decorative coloured lights available in the cabin.
 
 LightIntensity:
   datatype: uint8
@@ -40,27 +46,69 @@ LightIntensity:
   min: 0
   max: 100
   description: Intensity of the interior lights. 0 = Off. 100 = Full brightness.
+  deprecation: V3.0 It will be removed to enable individual control of lights via the SingleConfigurableLight.vspec. 
+  comment: Use Cabin.Lights.PerceivedAmbientLight for sensing the amount of visible light. Use SingleConfigurableLight.vspec to describe other types of interior lights that can be configured.
 
-#
-# First / front row lights
-#
 Spotlight:
   type: branch
-  instances: Row[1,4]
+  instances: 
+    - Row[1,4]
+    - ["Left","Shared","Right"]
   description: Spotlight for a specific area in the vehicle.
+
+Spotlight.IsLightOn:
+  datatype: boolean
+  type: sensor
+  description: Is a light on. 0=False, 1=True.
 
 Spotlight.IsSharedOn:
   datatype: boolean
   type: sensor
   description: Is a shared light across a specific row on
+  deprecation: It will be removed. Use Vehicle.Cabin.Lights.Spotlight.Row[1..4].['Left',..].IsLightOn
 
 Spotlight.IsLeftOn:
   datatype: boolean
   type: actuator
   description: Is light on the left side switched on
+  deprecation: It will be removed. Use Vehicle.Cabin.Lights.Spotlight.Row[1..4].['Left',..].IsLightOn
 
 
 Spotlight.IsRightOn:
   datatype: boolean
   type: actuator
   description: Is light on the right side switched on
+  deprecation: It will be removed. Use Vehicle.Cabin.Lights.Spotlight.Row[1..4].['Left',..].IsLightOn
+
+#
+# Configurable lights
+#
+AmbientLight:
+  type: branch
+  instances: 
+    - Row[1,2]
+    - ["Left","Shared","Right"]
+  description: Decorative coloured light inside the cabin, usually mounted on the door, cealing, etc.
+
+AmbientLight.Intensity:
+  type: actuator
+  datatype: uint8
+  unit: percent
+  min: 0
+  max: 100
+  description: Percentage attenuation of light expressed as a fraction of the maximum intensity. 0 = Off. 100 = Full brightness.
+
+AmbientLight.RGBColor:
+  type: actuator
+  datatype: uint8[]
+  arraysize: 3
+  min: 0
+  max: 255
+  description: RGB color represented as an array of [Red, Green, Blue].
+
+AmbientLight.ColorCode:
+  type: actuator
+  datatype: uint8
+  min: 0
+  max: 100
+  description: Color represented with a custom code. User is responsible of the final mapping.

--- a/spec/Cabin/InteriorLights.vspec
+++ b/spec/Cabin/InteriorLights.vspec
@@ -1,5 +1,5 @@
 #
-# (C) 
+# (C) 2023 BMW Group
 # (C) 2018 Volvo Cars
 # (C) 2016 Jaguar Land Rover
 #
@@ -48,67 +48,3 @@ LightIntensity:
   description: Intensity of the interior lights. 0 = Off. 100 = Full brightness.
   deprecation: V3.0 It will be removed to enable individual control of lights via the SingleConfigurableLight.vspec. 
   comment: Use Cabin.Lights.PerceivedAmbientLight for sensing the amount of visible light. Use SingleConfigurableLight.vspec to describe other types of interior lights that can be configured.
-
-Spotlight:
-  type: branch
-  instances: 
-    - Row[1,4]
-    - ["Left","Shared","Right"]
-  description: Spotlight for a specific area in the vehicle.
-
-Spotlight.IsLightOn:
-  datatype: boolean
-  type: sensor
-  description: Is a light on. 0=False, 1=True.
-
-Spotlight.IsSharedOn:
-  datatype: boolean
-  type: sensor
-  description: Is a shared light across a specific row on
-  deprecation: It will be removed. Use Vehicle.Cabin.Lights.Spotlight.Row[1..4].['Left',..].IsLightOn
-
-Spotlight.IsLeftOn:
-  datatype: boolean
-  type: actuator
-  description: Is light on the left side switched on
-  deprecation: It will be removed. Use Vehicle.Cabin.Lights.Spotlight.Row[1..4].['Left',..].IsLightOn
-
-
-Spotlight.IsRightOn:
-  datatype: boolean
-  type: actuator
-  description: Is light on the right side switched on
-  deprecation: It will be removed. Use Vehicle.Cabin.Lights.Spotlight.Row[1..4].['Left',..].IsLightOn
-
-#
-# Configurable lights
-#
-AmbientLight:
-  type: branch
-  instances: 
-    - Row[1,2]
-    - ["Left","Shared","Right"]
-  description: Decorative coloured light inside the cabin, usually mounted on the door, cealing, etc.
-
-AmbientLight.Intensity:
-  type: actuator
-  datatype: uint8
-  unit: percent
-  min: 0
-  max: 100
-  description: Percentage attenuation of light expressed as a fraction of the maximum intensity. 0 = Off. 100 = Full brightness.
-
-AmbientLight.RGBColor:
-  type: actuator
-  datatype: uint8[]
-  arraysize: 3
-  min: 0
-  max: 255
-  description: RGB color represented as an array of [Red, Green, Blue].
-
-AmbientLight.ColorCode:
-  type: actuator
-  datatype: uint8
-  min: 0
-  max: 100
-  description: Color represented with a custom code. User is responsible of the final mapping.

--- a/spec/Cabin/InteriorLights.vspec
+++ b/spec/Cabin/InteriorLights.vspec
@@ -1,5 +1,5 @@
 #
-# (C) 2023 BMW Group
+# (C) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 # (C) 2018 Volvo Cars
 # (C) 2016 Jaguar Land Rover
 #
@@ -48,3 +48,36 @@ LightIntensity:
   description: Intensity of the interior lights. 0 = Off. 100 = Full brightness.
   deprecation: V3.0 It will be removed to enable individual control of lights via the SingleConfigurableLight.vspec. 
   comment: Use Cabin.Lights.PerceivedAmbientLight for sensing the amount of visible light. Use SingleConfigurableLight.vspec to describe other types of interior lights that can be configured.
+
+
+#
+# Configurable lights
+#
+Spotlight:
+  type: branch
+  instances: 
+    - Row[1,2]
+    - ["Driver","Passenger"]
+  description: Spotlight for a specific area in the vehicle.
+#include SingleConfigurableLight.vspec Spotlight
+
+
+AmbientLight:
+  type: branch
+  instances: 
+    - Row[1,2]
+    - ["Driver","Passenger"]
+  description: Decorative coloured light inside the cabin, usually mounted on the door, cealing, etc.
+#include SingleConfigurableLight.vspec AmbientLight
+
+InteractiveLightBar:
+  type: branch
+  description: Decorative coloured light bar that supports effects. It is usually mounted on the dashboard (e.g., BMW i7 Interactive bar).
+#include SingleConfigurableLight.vspec InteractiveLightBar
+
+InteractiveLightBar.Effect:
+  type: actuator
+  allowed: ['NO_EFFECT', 'GRADIENT_DRIVER', 'GRADIENT_PASSENGER']
+  datatype: string
+  description: Light effect selection.
+

--- a/spec/Cabin/SingleConfigurableLight.vspec
+++ b/spec/Cabin/SingleConfigurableLight.vspec
@@ -1,0 +1,29 @@
+#
+# (C) 2023 BMW Group
+#
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
+#
+
+#
+# Generic specification for a light whose color and brightness can be configured.
+#
+
+IsLightOn:
+  type: actuator
+  datatype: boolean
+  description: Indicates whether the light is turned on. True=On, False=Off.
+
+Intensity:
+  type: actuator
+  datatype: uint8
+  unit: percent
+  min: 1
+  max: 100
+  description: How much of the maximum possible brightness of the light. is used. 1 = Maximum attenuation, 100 = no attenuation (i.e., full brightness).
+  comment: Attenuation = 100 - Intensity.
+
+Color:
+  type: actuator
+  datatype: string
+  description: Hexadecimal color code.

--- a/spec/Cabin/SingleConfigurableLight.vspec
+++ b/spec/Cabin/SingleConfigurableLight.vspec
@@ -1,5 +1,5 @@
 #
-# (C) 2023 BMW Group
+# (C) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 #
 # All files and artifacts in this repository are licensed under the
 # provisions of the license provided by the LICENSE file in this repository.
@@ -12,7 +12,7 @@
 IsLightOn:
   type: actuator
   datatype: boolean
-  description: Indicates whether the light is turned on. True=On, False=Off.
+  description: Indicates whether the light is turned on. True = On, False = Off.
 
 Intensity:
   type: actuator


### PR DESCRIPTION
feat: Improve the specification of interior lights to address issue #531 . Key aspects are listed below:

* `SingleConfigurableLight.vspec` defined for generic lights whose color, intensity, and state can be acted on.
* Changed previous name of `AmbientLight` to `PerceivedAmbientLight`. Previous definition was referring to the act of sensing the existing light in the ambient. 
* `AmbientLight` redefined as `actuator`.
* Examples of configurable lights included: `AmbientLight` and `Spotlight`
* Add new concept for interactive lights, where an effect can be selected. 