### PR TITLE
fix: Correct types in OBD specification

### DIFF
--- a/spec/OBD/OBD.vspec
+++ b/spec/OBD/OBD.vspec
@@ -1,4 +1,5 @@
 #
+# (C) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 # (C) 2020 Robert Bosch GmbH
 # (C) 2018 Volvo Cars
 # (C) 2016 Jaguar Land Rover
@@ -33,9 +34,10 @@
 #
 
 PidsA:
-  datatype: uint32
-  type: sensor
-  description: PID 00 - Bit array of the supported pids 01 to 20
+  datatype: string[]
+  type: attribute
+  allowed: ["01",	"02", "03",	"04",	"05",	"06",	"07",	"08",	"09",	"0A",	"0B",	"0C",	"0D",	"0E",	"0F",	"10",	"11",	"12",	"13",	"14",	"15",	"16",	"17",	"18",	"19",	"1A",	"1B",	"1C",	"1D",	"1E",	"1F",	"20"]
+  description: PID 00 - Bit array of the supported pids 01 to 20 in Hexadecimal.
 
 Status:
   type: branch
@@ -49,11 +51,11 @@ Status.IsMILOn:
 Status.DTCCount:
   datatype: uint8
   type: sensor
-  description: Number of sensor Trouble Codes (DTC)
+  description: Number of Diagnostic Trouble Codes (DTC)
 
 Status.IgnitionType:
   datatype: string
-  type: sensor
+  type: attribute
   allowed: ['SPARK', 'COMPRESSION']
   description: Type of the ignition for ICE - spark = spark plug ignition, compression = self-igniting (Diesel engines)
 
@@ -450,8 +452,10 @@ MaxMAF:
   description: PID 50 - Maximum flow for mass air flow sensor
 
 FuelType:
-  datatype: string
-  type: sensor
+  datatype: uint8
+  type: attribute
+  min: 0
+  max: 23
   description: PID 51 - Fuel type
 
 EthanolPercent:


### PR DESCRIPTION
It addresses the issue #544. Minor changes in the types described for OBD data. 