### PR TITLE
Making Window Positon and ChildLock an Actuator

### DIFF
--- a/spec/Cabin/Cabin.vspec
+++ b/spec/Cabin/Cabin.vspec
@@ -121,6 +121,12 @@ DoorCount:
   description: Number of doors in vehicle.
 
 
+IsWindowChildLockEngaged:
+  datatype: boolean
+  type: actuator
+  description: Is window child lock engaged. True = Engaged. False = Disengaged.
+  comment: Window child lock refers to the functionality to disable the move window button next to most windows,
+           so that they only can be operated by the driver.
 
 ##
 # Seat signals and attributes

--- a/spec/Cabin/SingleDoor.vspec
+++ b/spec/Cabin/SingleDoor.vspec
@@ -36,7 +36,8 @@ Window:
 IsChildLockActive:
   datatype: boolean
   type: sensor
-  description: Is door child lock engaged. True = Engaged. False = Disengaged.
+  description: Is door child lock active. True = Door cannot be opened from inside.
+               False = Door can be opened from inside.
 
 #
 # Window shade / curtain status

--- a/spec/Cabin/SingleWindow.vspec
+++ b/spec/Cabin/SingleWindow.vspec
@@ -25,6 +25,7 @@ Position:
 IsChildLockEngaged:
   datatype: boolean
   type: actuator
+  instantiate: False
   description: Is window child lock engaged. True = Engaged. False = Disengaged.
 
 # Include the window controlling switch and attach it to the

--- a/spec/Cabin/SingleWindow.vspec
+++ b/spec/Cabin/SingleWindow.vspec
@@ -22,12 +22,6 @@ Position:
   unit: percent
   description: Window position. 0 = Fully closed 100 = Fully opened.
 
-IsChildLockEngaged:
-  datatype: boolean
-  type: actuator
-  instantiate: False
-  description: Is window child lock engaged. True = Engaged. False = Disengaged.
-
 # Include the window controlling switch and attach it to the
 # window branch
 #include SingleSliderSwitch.vspec

--- a/spec/Cabin/SingleWindow.vspec
+++ b/spec/Cabin/SingleWindow.vspec
@@ -16,7 +16,7 @@ IsOpen:
 
 Position:
   datatype: uint8
-  type: sensor
+  type: actuator
   min: 0
   max: 100
   unit: percent
@@ -24,7 +24,7 @@ Position:
 
 IsChildLockEngaged:
   datatype: boolean
-  type: sensor
+  type: actuator
   description: Is window child lock engaged. True = Engaged. False = Disengaged.
 
 # Include the window controlling switch and attach it to the


### PR DESCRIPTION
This makes `Window.Position` and `Window. IsChildLockEngaged` actuator. I think it being a sensor is a bug, as a VSS App might want to set Window Position (I think I have  actually even seen this in examples on ppt level from time time)

I kept `IsOpen`  as pure sensor, as I interpret that to be true for any position != 0, so setting it has no real meaning.

There _are_ Window controls modelled in form of a switch in Window.Switch

```
Switch:
  datatype: string
  type: actuator
  allowed: ['INACTIVE', 'CLOSE', 'OPEN', 'ONE_SHOT_CLOSE', 'ONE_SHOT_OPEN']
  description: Switch controlling sliding action such as window, sunroof, or blind.
```

But I think that is not the same/complimentary. 

Example: If you set a certain Window position in for example in an app, or some hypothetical function in the car that prevents a dog from being grilled in a parked car, likely you would like to set the window to certain position directly and not "simulating" button presses