### PR TITLE
Add auto apply for parking brake

### DIFF
--- a/spec/Chassis/Chassis.vspec
+++ b/spec/Chassis/Chassis.vspec
@@ -116,7 +116,10 @@ ParkingBrake.IsEngaged:
   type: actuator
   description: Parking brake status. True = Parking Brake is Engaged. False = Parking Brake is not Engaged.
 
-
+ParkingBrake.IsAutoApplyEnabled:
+  datatype: boolean
+  type: actuator
+  description: Indicates if parking brake will be automatically engaged when the vehicle engine is turned off.
 #
 # Steering Wheel
 #


### PR DESCRIPTION
Many vehicles with electrical parking brake have a button/setting to control whether parking brake shall be automatically engaged or not when engine is turned off. 