### PR TITLE
Add description to brake lights

### DIFF
--- a/spec/Body/Body.vspec
+++ b/spec/Body/Body.vspec
@@ -224,6 +224,7 @@ Lights.LicensePlate:
 
 Lights.Brake:
   type: branch
+  description: Brake lights.
 #include BrakeLights.vspec Lights.Brake
 
 Lights.Hazard:


### PR DESCRIPTION
Description is mandatory according to current description, see https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/ and https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/
Lack of description has caused problem in downstream tools.
