### PR TITLE
Add description to brake lights

### DIFF
--- a/spec/Body/Body.vspec
+++ b/spec/Body/Body.vspec
@@ -224,6 +224,7 @@ Lights.LicensePlate:
 
 Lights.Brake:
   type: branch
+  description: Brake lights.
 #include BrakeLights.vspec Lights.Brake
 
 Lights.Hazard:


### PR DESCRIPTION
Description is mandatory according to current description.
This fix was included in VSS 3.1.1.
As it currently is considered as bug to not have a description I consider this as a bug that can be merged ASAP if CI succeeds