### PR TITLE
Adding DCO check

### DIFF
--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -1,0 +1,13 @@
+# This check verifies that commits are signed-off
+# That is a requirement according to COVESA guidelines
+# See https://www.covesa.global/contribute
+# To sign-off use "git commit -s"
+name: DCO
+
+on: [pull_request]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tisonkun/actions-dco@v1.1


### PR DESCRIPTION
PR intended to check for sign-offs. If we think this is a good addition we can add it to vss-tools as well.


When signed we get something like:

![image](https://user-images.githubusercontent.com/30996601/228178968-0dd0809d-3e6f-4723-af88-33d684cd1bf5.png)


Result when this commit was not signed

```
Run pip3 install -U dco-check
Collecting dco-check
  Downloading dco_check-0.4.0-py3-none-any.whl (18 kB)
Installing collected packages: dco-check
Successfully installed dco-check-0.4.0
Detected: GitHub CI

Checking commits: 1020b7ce6a1ec3ba31a667b1af7de06af3b49261..5f94023b70cdae05188881b767a7a56080c4010c

Missing sign-off(s):

	5f94023b70cdae05188881b767a7a56080c4010c
		no sign-off found
Error: Process completed with exit code 1.
```
