### PR TITLE
Clarify that VSS is case sensitive.

### DIFF
--- a/docs-gen/content/rule_set/basics.md
+++ b/docs-gen/content/rule_set/basics.md
@@ -17,6 +17,11 @@ The raw specification files can, with help of tools in the [vss-tools repository
 be converted to other formats that are more user friendly to read.
 Converted representations are also included as release artifacts for each [VSS release](https://github.com/COVESA/vehicle_signal_specification/releases).
 
+VSS is in itself case sensitive.
+This means that keywords, signal names, types and values normally shall be given with the case specified.
+It is however recommended not to take advantage of this and reuse the same name with different case,
+as some implementations may treat VSS identifiers as case insensitive.
+
 ## Addressing Nodes
 
 Tree nodes are addressed, left-to-right, from the root of the tree

--- a/spec/Powertrain/Battery.vspec
+++ b/spec/Powertrain/Battery.vspec
@@ -234,7 +234,7 @@ Charging.IsChargingCableConnected:
 
 Charging.IsChargingCableLocked:
   datatype: boolean
-  type: Actuator
+  type: actuator
   description: Is charging cable locked to prevent removal.
   comment: Locking of charging cable can be used to prevent unintentional removing during charging.
 


### PR DESCRIPTION
This is part of #562.
The idea is that when this has been accepted we can refactor vss-tools and remove functionality for case-insensitive handling. (Which by the way is not handled consistently)

For that to work we must make sure we specify type consistently for existing signals