### PR TITLE
Proposal for improved vss-tools export format control

### DIFF
--- a/EXPORT_HELPERS.md
+++ b/EXPORT_HELPERS.md
@@ -1,9 +1,10 @@
 ## Proposal / Discussion Draft: Consistent & Documented Export Formats
 
-Goal of this proposal is to get consistent and conformant formatted exports of the VSS,
-from VSS-TOOLS or other potential 3rd-party implementations, resulting in a high degree of
-interoperability between implementations using a particular format (such as IDL), and to
-ease the creation of interoperable examples and reference implementations for a given format.
+Goal of this proposal is to produce consistent and conformant formatted exports of the VSS via
+the VSS-TOOLS or other potential 3rd-party implementations, resulting in a high degree of stability and
+interoperability between implementations using a particular format (such as IDL).
+
+This consistency and stability can ease the creation of interoperable examples and reference implementations for a given format.  
 This draft focuses on IDL, but is intended to also maximize interoperability within other export formats.
 
 To enable this capability, the following changes are proposed:
@@ -11,12 +12,14 @@ To enable this capability, the following changes are proposed:
 - Create a document to describe the recommended formatting and structure of the resulting exported (IDL or other) files.
 - Modify the exporters in VSS-TOOLS to conform to the above document.
 - Utilize the `arraysize` and `stringsizemax` to set the dimensions of the exported array/sequence/string types.
-- Introduce 3 new keywords to the VSS: `memberof`, `membergroup`, `isogroup` to be used as:
+- Introduce 3 new keywords to the VSS: `memberof`, `membergroup`, `isogroup`, used as:
     - To have a `branch` entity create a namespace in the export (named for itself), add:
         - `memberof: namespace`
     - To create named group containers in the export for elements, add to the branch entry:
-        - `membergroup <list of names>` to create containers that may be referenced in the parent of this branch.
+        - `membergroup <list of names>` to create containers that may also be referenced in the parent of this branch.
         - `isogroup <list of names>` to create containers that will not be referenced in the parent of this branch.
+    - To assign `membergroup` struct names to be referenced in a parent struct:
+        - `memberof: <list of parent struct names to insert reference into>`
     - To assign VSS elements to specific named group containers in the export, add to element entry:
         - `memberof: <list of group containers>`
 
@@ -27,7 +30,7 @@ information to consistently produce IDL that conforms to the above document.
 
 Examples of this export guidance on IDL includes:  
 
-**Namespaces**  
+### Namespaces
 In IDL, namespaces are expressed with a `module { ... }` container around the affected definitions.
 A sensible approach to namespacing in VSS would be to use containers for the major sections of
 the specification, such as: `ADAS`, `Body`, `Cabin`, `Chassis`, `OBD`, and `Powertrain`, all residing
@@ -45,7 +48,7 @@ within a top-level container for `Vehicle`.   The resulting IDL would look like:
 Note that only the `branch` entries that have this keyword will receive a namespace for their descendent types.
 All `branch` entries beneath them will be implemented as `struct`.
 
-**Creating structs from VSS elements**  
+### Creating structs from VSS elements
 Using the new keywords to define and assign elements to structs, the VSS can be tailored to match the intended usage
 patterns of the underlying signals.  For example:
 
@@ -119,10 +122,10 @@ such as:
   };
 ```
 
-**Including Descendent Structs in Parent Structs**
+### Including Descendent Structs in Parent Structs
 The VSS structure in some places implies that a struct might be included in its parent struct, 
 such as how `Vehicle.Powertrain.TractionBattery` might want to include its `Temperature` and `StateOfCharge` 
-descendant structs -- but there is no guidance in the VSS to support this grouping.
+descendant structs -- but there is no directive in the VSS to enforce this grouping.
 
 The added keywords could enforce the inclusion of references to descendant types within a parent,
 enabling data structures such as:
@@ -154,12 +157,13 @@ in the controlling document for each format (IDL, etc.).  For the IDL example, t
 
 
 ## Rationale
-This change seeks to enable VSS to take the most advantage of the capabilities of IDL and DDS.
+This change seeks to enable VSS to take the most advantage of the capabilities of IDL and DDS.  
 DDS (Data Description Service) is a (very) data-centric communications framework that uses IDL as its primary type definition language.
 Systems built on DDS can take advantage of the features that are built-in to the DDS standard, thereby avoiding the need to create 
-these features -- DDS handles it.  Some capabilities (in brief):
+these features -- DDS handles it.  
+Some capabilities (in brief):
 
-- **Content Filtering**: Subscribers to data topics can designate a filtering specification on the data elements within that topic, such as only allowing temperature readings if they are above 90C.  This filtering spec can be automatically moved to the *publisher* of that data, wherein it won't put data on the network if it doesn't meet the filter spec for the subscriber.
+- **Content Filtering**: Subscribers to data topics can designate a filtering specification on the data elements within that topic's data type, such as only allowing temperature readings if they are above 90C.  This filtering spec can be automatically moved to the *publisher* of that data, wherein it won't put data on the network if it doesn't meet the filter spec for the subscriber.
 
 - **Keyed Topics**: a data type definition (struct) can have one or more members designated as a `key`; This key 
 value will uniquely identify the source of the data, enabling many sources to share the same data topic 
@@ -175,6 +179,8 @@ assured of interoperability by using common data type definitions.   This approa
 to ensure interoperability between independently-created applications.
 
 This is why it's so important when expressing the VSS in IDL through a stable set of data type definitions, that they represent
-the most common usage patterns (groupings) for those signals.
+the most common usage patterns (groupings) for those signals -- and retain a consistent and stable type definition to ensure interoperability.
+Also note that DDS supports the notion of *type extensibility*, whereby elements can be appended to types while still retaining
+forward & backward compatibility.
 
 (Looking forward to a lively discussion :) 

--- a/EXPORT_HELPERS.md
+++ b/EXPORT_HELPERS.md
@@ -1,0 +1,180 @@
+## Proposal / Discussion Draft: Consistent & Documented Export Formats
+
+Goal of this proposal is to get consistent and conformant formatted exports of the VSS,
+from VSS-TOOLS or other potential 3rd-party implementations, resulting in a high degree of
+interoperability between implementations using a particular format (such as IDL), and to
+ease the creation of interoperable examples and reference implementations for a given format.
+This draft focuses on IDL, but is intended to also maximize interoperability within other export formats.
+
+To enable this capability, the following changes are proposed:
+
+- Create a document to describe the recommended formatting and structure of the resulting exported (IDL or other) files.
+- Modify the exporters in VSS-TOOLS to conform to the above document.
+- Utilize the `arraysize` and `stringsizemax` to set the dimensions of the exported array/sequence/string types.
+- Introduce 3 new keywords to the VSS: `memberof`, `membergroup`, `isogroup` to be used as:
+    - To have a `branch` entity create a namespace in the export (named for itself), add:
+        - `memberof: namespace`
+    - To create named group containers in the export for elements, add to the branch entry:
+        - `membergroup <list of names>` to create containers that may be referenced in the parent of this branch.
+        - `isogroup <list of names>` to create containers that will not be referenced in the parent of this branch.
+    - To assign VSS elements to specific named group containers in the export, add to element entry:
+        - `memberof: <list of group containers>`
+
+## Effect on IDL Export
+Implementing the above keywords into the VSS -- to enforce the guidance of the above reference document -- 
+should have no effect on existing exporters in VSS-TOOLS, however a modified IDL exporter could use this new
+information to consistently produce IDL that conforms to the above document.
+
+Examples of this export guidance on IDL includes:  
+
+**Namespaces**  
+In IDL, namespaces are expressed with a `module { ... }` container around the affected definitions.
+A sensible approach to namespacing in VSS would be to use containers for the major sections of
+the specification, such as: `ADAS`, `Body`, `Cabin`, `Chassis`, `OBD`, and `Powertrain`, all residing
+within a top-level container for `Vehicle`.   The resulting IDL would look like:
+```
+  module Vehicle {
+    module Cabin {
+      (struct and enum definitions for Cabin descendants)
+    };
+    module Chassis {
+      (struct and enum definitions for Chassis descendants)
+    };
+  };
+```
+Note that only the `branch` entries that have this keyword will receive a namespace for their descendent types.
+All `branch` entries beneath them will be implemented as `struct`.
+
+**Creating structs from VSS elements**  
+Using the new keywords to define and assign elements to structs, the VSS can be tailored to match the intended usage
+patterns of the underlying signals.  For example:
+
+Some signals should 'obviously' be grouped together, such as `Vehicle.AngularVelocity`, `Vehicle.CurrentLocation`, etc..,
+resulting in structs that match this most likely usage pattern:
+```
+  struct AngularVelocity {
+    float Roll;
+    float Pitch;
+    float Yaw;
+  };
+```
+
+Other signals are not as clear in their implied grouping, such as the signals directly under `Vehicle`:
+```
+  string StartTime attribute
+  int16 RoofLoad attribute
+  float CargoVolume attribute
+  int16 EmissionsCO2 attribute
+  uint16 CurbWeight attribute
+  uint16 GrossWeight attribute
+  uint16 MaxTowWeight attribute
+  uint16 MaxTowBallWeight attribute
+  uint16 Length attribute
+  uint16 Height attribute
+  uint16 Width attribute
+  string LowVoltageSystemState sensor
+  float Speed sensor
+  float TravelledDistance sensor
+  float TraveledDistance sensor
+  float TraveledDistanceSinceStart sensor
+  float TripDuration sensor
+  boolean IsBrokenDown sensor
+  boolean IsMoving sensor
+  float AverageSpeed sensor
+  uint16 CurrentOverallWeight sensor
+  float TripMeterReading actuator
+  uint8 PowerOptimizeLevel actuator
+```
+Even if split into separate structs for `attribute`, `sensor`, and `actuator`, using this "implied-by-proximity"
+grouping might not represent the actual usage pattern of each VSS member.
+
+However, if each VSS member could be assigned to a named struct, then the expected usage patterns for all signals
+could be mapped and made part of the VSS specification itself.   This could result in data type (struct) definitions
+such as:
+```
+  struct VehicleAttributes {
+    string StartTime;
+    int16 RoofLoad;
+    float CargoVolume;
+    int16 EmissionsCO2;
+    uint16 CurbWeight;
+    uint16 GrossWeight;
+    uint16 MaxTowWeight;
+    uint16 MaxTowBallWeight;
+    uint16 Length;
+    uint16 Height;
+    uint16 Width;
+  };
+  struct Vehicle_Sensor_customName_whatever {
+    string LowVoltageSystemState;
+    float Speed;
+    float TravelledDistance;
+    float TraveledDistance;
+    float TraveledDistanceSinceStart;
+    float TripDuration;
+    boolean IsBrokenDown;
+    boolean IsMoving;
+    float AverageSpeed;
+    uint16 CurrentOverallWeight;
+  };
+```
+
+**Including Descendent Structs in Parent Structs**
+The VSS structure in some places implies that a struct might be included in its parent struct, 
+such as how `Vehicle.Powertrain.TractionBattery` might want to include its `Temperature` and `StateOfCharge` 
+descendant structs -- but there is no guidance in the VSS to support this grouping.
+
+The added keywords could enforce the inclusion of references to descendant types within a parent,
+enabling data structures such as:
+```
+  module Vehicle {
+    module Powertrain {
+      struct TractionBattery_Temperature {
+        (temperature members)
+      };
+      struct TractionBattery_StateOfCharge {
+        (stateOfCharge members)
+      };
+      struct TractionBattery_Sensors {
+        (sensor member elements of TractionBattery)
+        TractionBattery_Temperature Temperature;
+        TractionBattery_StateOfCharge StateOfCharge;
+      };
+    };
+  };
+```
+
+## Other export rules to be defined in document
+The behaviors of format-specific features that do not require assistance in the VSS will be defined
+in the controlling document for each format (IDL, etc.).  For the IDL example, this might include:
+
+- How to interpret VSS `instances`, as they can translate nicely to DDS keyed topics with an enumerated key value, or to a non-keyed topic that uses content filtering.
+- How to interpret VSS `allowed` values; as enums, or string values.
+- How to ensure `enum` members do not have namespace collisions with other enum members, including when used with `C` programming language.
+
+
+## Rationale
+This change seeks to enable VSS to take the most advantage of the capabilities of IDL and DDS.
+DDS (Data Description Service) is a (very) data-centric communications framework that uses IDL as its primary type definition language.
+Systems built on DDS can take advantage of the features that are built-in to the DDS standard, thereby avoiding the need to create 
+these features -- DDS handles it.  Some capabilities (in brief):
+
+- **Content Filtering**: Subscribers to data topics can designate a filtering specification on the data elements within that topic, such as only allowing temperature readings if they are above 90C.  This filtering spec can be automatically moved to the *publisher* of that data, wherein it won't put data on the network if it doesn't meet the filter spec for the subscriber.
+
+- **Keyed Topics**: a data type definition (struct) can have one or more members designated as a `key`; This key 
+value will uniquely identify the source of the data, enabling many sources to share the same data topic 
+without identity contention.
+
+- **Transport Independence**: system design is decoupled from the underlying transport, meaning that the application software need not change if the application uses TCP, UDP, Shared Memory, Serial, Radio, Backplane, etc.   Secure or insecure transports, reliable or not.
+
+- **A long list of capabilities** -- time-based filtering, persistence, liveliness, security, reliability, redundancy, batching, type extensibility, and many more capabilities are part of the open/published standard of DDS, from which more than 12 implementations have been created.
+
+Systems based on DDS do well by having a defined set of data types, from which many applications can be created and will be
+assured of interoperability by using common data type definitions.   This approach has been very successful in the ROS
+(Robot Operating System) ecosystem, which uses a common set of data types and a data-centric communications framework (DDS)
+to ensure interoperability between independently-created applications.
+
+This is why it's so important when expressing the VSS in IDL through a stable set of data type definitions, that they represent
+the most common usage patterns (groupings) for those signals.
+
+(Looking forward to a lively discussion :) 

--- a/docs-gen/content/introduction/overview.md
+++ b/docs-gen/content/introduction/overview.md
@@ -40,7 +40,7 @@ The figure below shows an example snapshot of a generated tree of the
 specification. The leafs contain the actual information as shown in the figure.
 Before going into detail of the specification, let's dig deeper into taxonomies.
 
-![Example tree](/vehicle_signal_specification/images/tree.png?classes=shadow&width=60pc)
+![Example tree](https://covesa.github.io/vehicle_signal_specification/images/tree.png?classes=shadow&width=60pc)
 
 ## VSS usage for other domains
 

--- a/docs-gen/content/introduction/overview.md
+++ b/docs-gen/content/introduction/overview.md
@@ -24,7 +24,7 @@ vehicle implementation details.
 
 While the data in the VSS standard catalog aims to be vendor-independent,
 vendor specific extensions and adaptations complying with the VSS syntax rules can be specified
-(see [Overlays](../rule_set/overlay.md).
+(see [Overlays](/vehicle_signal_specification/docs-gen/content/rule_set/overlay.md).
 
 ### What's in
 * Standardized data definition for vehicle signals.

--- a/docs-gen/content/introduction/overview.md
+++ b/docs-gen/content/introduction/overview.md
@@ -24,7 +24,7 @@ vehicle implementation details.
 
 While the data in the VSS standard catalog aims to be vendor-independent,
 vendor specific extensions and adaptations complying with the VSS syntax rules can be specified
-(see [Overlays](/vehicle_signal_specification/docs-gen/content/rule_set/overlay.md).
+(see [Overlays](https://covesa.github.io/vehicle_signal_specification/rule_set/overlay/)).
 
 ### What's in
 * Standardized data definition for vehicle signals.

--- a/docs-gen/content/rule_set/instances.md
+++ b/docs-gen/content/rule_set/instances.md
@@ -44,7 +44,7 @@ But there are cases, when nodes are linked more the general concept of
 a branch, but not to the single instance. This could be the `DoorCount`,
 which would rather be `Door.Count`, `WheelDiameter`, which is rather linked
 to an axle rather than the wheel itself or `Brake.FluidLevel` which is not
-measured for a single break, but rather a system indication. 
+measured for a single brake, but rather a system indication. 
 
 To exclude a child-node from the instantiation of the *direct* parent node, set the
 keyword `instantiate` to `false` (`true` by default). Please check the following

--- a/vss_dedupe.txt
+++ b/vss_dedupe.txt
@@ -1,0 +1,572 @@
+['Vehicle:VersionVSS']
+  attribute uint32 Major
+  attribute uint32 Minor
+  attribute uint32 Patch
+  attribute string Label
+['Vehicle:VehicleIdentification']
+  attribute string VIN
+  attribute string WMI
+  attribute string Brand
+  attribute string Model
+  attribute uint16 Year
+  attribute string AcrissCode
+  attribute string BodyType
+  attribute string DateVehicleFirstRegistered
+  attribute string MeetsEmissionStandard
+  attribute string ProductionDate
+  attribute string PurchaseDate
+  attribute string VehicleModelDate
+  attribute string VehicleConfiguration
+  attribute uint16 VehicleSeatingCapacity
+  attribute string VehicleSpecialUsage
+  attribute string VehicleInteriorColor
+  attribute string VehicleInteriorType
+  attribute string KnownVehicleDamages
+  attribute string[] OptionalExtras
+['Vehicle']
+  attribute string StartTime
+  attribute int16 RoofLoad
+  attribute float CargoVolume
+  attribute int16 EmissionsCO2
+  attribute uint16 CurbWeight
+  attribute uint16 GrossWeight
+  attribute uint16 MaxTowWeight
+  attribute uint16 MaxTowBallWeight
+  attribute uint16 Length
+  attribute uint16 Height
+  attribute uint16 Width
+  sensor    string LowVoltageSystemState
+  sensor    float Speed
+  sensor    float TravelledDistance
+  sensor    float TraveledDistance
+  sensor    float TraveledDistanceSinceStart
+  sensor    float TripDuration
+  sensor    boolean IsBrokenDown
+  sensor    boolean IsMoving
+  sensor    float AverageSpeed
+  sensor    uint16 CurrentOverallWeight
+  actuator  float TripMeterReading
+  actuator  uint8 PowerOptimizeLevel
+['Vehicle:LowVoltageBattery']
+  attribute uint16 NominalVoltage
+  attribute uint16 NominalCapacity
+  sensor    float CurrentVoltage
+  sensor    float CurrentCurrent
+['Vehicle:Acceleration']
+  sensor    float Longitudinal
+  sensor    float Lateral
+  sensor    float Vertical
+['Vehicle:AngularVelocity']
+  sensor    float Roll
+  sensor    float Pitch
+  sensor    float Yaw
+['Vehicle:Trailer']
+  sensor    boolean IsConnected
+['Vehicle:CurrentLocation']
+  sensor    string Timestamp
+  sensor    double Latitude
+  sensor    double Longitude
+  sensor    double Heading
+  sensor    double HorizontalAccuracy
+  sensor    double Altitude
+  sensor    double VerticalAccuracy
+['Vehicle:CurrentLocation:GNSSReceiver']
+  sensor    string FixType
+['Vehicle:CurrentLocation:GNSSReceiver:MountingPosition']
+  attribute int16 X
+  attribute int16 Y
+  attribute int16 Z
+['Vehicle:Powertrain']
+  attribute string Type
+  sensor    float AccumulatedBrakingEnergy
+  sensor    uint32 Range
+  actuator  uint8 PowerOptimizeLevel
+['Vehicle:Powertrain:CombustionEngine']
+  attribute string EngineCode
+  attribute uint16 Displacement
+  attribute float StrokeLength
+  attribute float Bore
+  attribute string Configuration
+  attribute uint16 NumberOfCylinders
+  attribute uint16 NumberOfValvesPerCylinder
+  attribute string CompressionRatio
+  attribute float EngineOilCapacity
+  attribute float EngineCoolantCapacity
+  attribute uint16 MaxPower
+  attribute uint16 MaxTorque
+  attribute string AspirationType
+  sensor    string EngineOilLevel
+  sensor    int32 OilLifeRemaining
+  sensor    boolean IsRunning
+  sensor    uint16 Speed
+  sensor    float EngineHours
+  sensor    float IdleHours
+  sensor    int16 ECT
+  sensor    int16 EOT
+  sensor    uint16 _MAP
+  sensor    uint16 MAF
+  sensor    uint8 TPS
+  sensor    uint16 EOP
+  sensor    uint16 Power
+  sensor    uint16 Torque
+['Vehicle:Powertrain:CombustionEngine:DieselExhaustFluid']
+  attribute float Capacity
+  sensor    uint8 Level
+  sensor    uint32 Range
+  sensor    boolean IsLevelLow
+['Vehicle:Powertrain:CombustionEngine:DieselParticulateFilter']
+  sensor    float InletTemperature
+  sensor    float OutletTemperature
+  sensor    float DeltaPressure
+['Vehicle:Powertrain:Transmission']
+  attribute string Type
+  attribute int8 GearCount
+  attribute string DriveType
+  sensor    float TravelledDistance
+  sensor    int8 CurrentGear
+  sensor    int16 Temperature
+  sensor    uint8 ClutchWear
+  actuator  int8 SelectedGear
+  actuator  boolean IsParkLockEngaged
+  actuator  boolean IsLowRangeEngaged
+  actuator  boolean IsElectricalPowertrainEngaged
+  actuator  string PerformanceMode
+  actuator  string GearChangeMode
+  actuator  float ClutchEngagement
+  actuator  float DiffLockFrontEngagement
+  actuator  float DiffLockRearEngagement
+  actuator  float TorqueDistribution
+['Vehicle:Powertrain:ElectricMotor']
+  attribute string EngineCode
+  attribute uint16 MaxPower
+  attribute uint16 MaxTorque
+  attribute uint16 MaxRegenPower
+  attribute uint16 MaxRegenTorque
+  sensor    int32 Speed
+  sensor    int16 Temperature
+  sensor    int16 CoolantTemperature
+  sensor    int16 Power
+  sensor    int16 Torque
+['Vehicle:Powertrain:TractionBattery']
+  attribute string Id
+  attribute string ProductionDate
+  attribute uint16 GrossCapacity
+  attribute uint16 NominalVoltage
+  attribute uint16 MaxVoltage
+  sensor    boolean IsPowerConnected
+  sensor    boolean IsGroundConnected
+  sensor    uint16 NetCapacity
+  sensor    float StateOfHealth
+  sensor    float CurrentVoltage
+  sensor    float CurrentCurrent
+  sensor    float CurrentPower
+  sensor    float AccumulatedChargedEnergy
+  sensor    float AccumulatedConsumedEnergy
+  sensor    float AccumulatedChargedThroughput
+  sensor    float AccumulatedConsumedThroughput
+  sensor    float PowerLoss
+  sensor    uint32 Range
+['Vehicle:Powertrain:TractionBattery:Temperature']
+  sensor    float Average
+  sensor    float Min
+  sensor    float Max
+['Vehicle:Powertrain:TractionBattery:StateOfCharge']
+  sensor    float Current
+  sensor    float Displayed
+  sensor    float CurrentEnergy
+['Vehicle:Powertrain:TractionBattery:Charging']
+  attribute string[] ChargePlugType
+  sensor    boolean IsChargingCableConnected
+  sensor    boolean IsCharging
+  sensor    boolean IsDischarging
+  sensor    float PowerLoss
+  sensor    float Temperature
+  sensor    float ChargeRate
+  sensor    uint32 TimeToComplete
+  actuator  uint8 ChargeLimit
+  actuator  string ChargePortFlap
+  actuator  boolean IsChargingCableLocked
+  actuator  string Mode
+  actuator  string StartStopCharging
+['Vehicle:Powertrain:TractionBattery:Charging:MaximumChargingCurrent', 'Vehicle:Powertrain:TractionBattery:Charging:ChargeCurrent']
+  sensor    float DC
+  sensor    float Phase1
+  sensor    float Phase2
+  sensor    float Phase3
+['Vehicle:Powertrain:TractionBattery:Charging:ChargeVoltage']
+  sensor    float DC
+  sensor    float Phase1
+  sensor    float Phase2
+  sensor    float Phase3
+['Vehicle:Powertrain:TractionBattery:Charging:Timer']
+  actuator  string Mode
+  actuator  string Time
+['Vehicle:Powertrain:TractionBattery:DCDC']
+  sensor    float PowerLoss
+  sensor    float Temperature
+['Vehicle:Powertrain:FuelSystem']
+  attribute string[] SupportedFuelTypes
+  attribute string[] SupportedFuel
+  attribute string HybridType
+  attribute float TankCapacity
+  sensor    float AbsoluteLevel
+  sensor    uint8 RelativeLevel
+  sensor    uint32 Range
+  sensor    float InstantConsumption
+  sensor    float AverageConsumption
+  sensor    float ConsumptionSinceStart
+  sensor    uint32 TimeSinceStart
+  sensor    boolean IsEngineStopStartEnabled
+  sensor    boolean IsFuelLevelLow
+['Vehicle:Body']
+  attribute string BodyType
+  attribute string RefuelPosition
+  actuator  float RearMainSpoilerPosition
+  actuator  uint8 PowerOptimizeLevel
+['Vehicle:Body:Hood']
+  actuator  boolean IsOpen
+['Vehicle:Body:Trunk:Front', 'Vehicle:Body:Trunk:Rear']
+  actuator  boolean IsOpen
+  actuator  boolean IsLocked
+['Vehicle:Body:Horn']
+  actuator  boolean IsActive
+['Vehicle:Body:Raindetection']
+  sensor    uint8 Intensity
+['Vehicle:Body:Windshield:Front:Wiping', 'Vehicle:Body:Windshield:Rear:Wiping']
+  sensor    uint8 WiperWear
+  sensor    boolean IsWipersWorn
+  actuator  string Mode
+  actuator  uint8 Intensity
+['Vehicle:Body:Windshield:Front:Wiping:System', 'Vehicle:Body:Windshield:Rear:Wiping:System']
+  sensor    float DriveCurrent
+  sensor    boolean IsWiping
+  sensor    boolean IsEndingWipeCycle
+  sensor    boolean IsWiperError
+  sensor    boolean IsPositionReached
+  sensor    boolean IsBlocked
+  sensor    boolean IsOverheated
+  actuator  string Mode
+  actuator  uint8 Frequency
+  actuator  float TargetPosition
+  actuator  float ActualPosition
+['Vehicle:Body:Windshield:Front', 'Vehicle:Body:Windshield:Rear']
+  actuator  boolean IsHeatingOn
+['Vehicle:Body:Windshield:Front:WasherFluid', 'Vehicle:Body:Windshield:Rear:WasherFluid']
+  sensor    boolean IsLevelLow
+  sensor    uint8 Level
+['Vehicle:Body:Lights']
+  actuator  string LightSwitch
+  actuator  boolean IsHighBeamSwitchOn
+['Vehicle:Body:Lights:Beam:Low', 'Vehicle:Body:Lights:Beam:High', 'Vehicle:Body:Lights:Running', 'Vehicle:Body:Lights:Backup', 'Vehicle:Body:Lights:Parking', 'Vehicle:Body:Lights:Fog:Rear', 'Vehicle:Body:Lights:Fog:Front', 'Vehicle:Body:Lights:LicensePlate']
+  sensor    boolean IsDefect
+  actuator  boolean IsOn
+['Vehicle:Body:Lights:Brake']
+  sensor    boolean IsDefect
+  actuator  string IsActive
+['Vehicle:Body:Lights:Hazard', 'Vehicle:Body:Lights:DirectionIndicator:Left', 'Vehicle:Body:Lights:DirectionIndicator:Right']
+  sensor    boolean IsDefect
+  actuator  boolean IsSignaling
+['Vehicle:Body:Mirrors:Left', 'Vehicle:Body:Mirrors:Right']
+  actuator  int8 Tilt
+  actuator  int8 Pan
+  actuator  boolean IsHeatingOn
+['Vehicle:Cabin:RearShade', 'Vehicle:Cabin:Sunroof:Shade', 'Vehicle:Cabin:Door:Row1:Left:Shade', 'Vehicle:Cabin:Door:Row1:Right:Shade', 'Vehicle:Cabin:Door:Row2:Left:Shade', 'Vehicle:Cabin:Door:Row2:Right:Shade']
+  actuator  string _Switch
+  actuator  uint8 Position
+['Vehicle:Cabin:HVAC:Station:Row1:Left', 'Vehicle:Cabin:HVAC:Station:Row1:Right', 'Vehicle:Cabin:HVAC:Station:Row2:Left', 'Vehicle:Cabin:HVAC:Station:Row2:Right', 'Vehicle:Cabin:HVAC:Station:Row3:Left', 'Vehicle:Cabin:HVAC:Station:Row3:Right', 'Vehicle:Cabin:HVAC:Station:Row4:Left', 'Vehicle:Cabin:HVAC:Station:Row4:Right']
+  actuator  uint8 FanSpeed
+  actuator  int8 Temperature
+  actuator  string AirDistribution
+['Vehicle:Cabin:HVAC']
+  sensor    float AmbientAirTemperature
+  actuator  boolean IsRecirculationActive
+  actuator  boolean IsFrontDefrosterActive
+  actuator  boolean IsRearDefrosterActive
+  actuator  boolean IsAirConditioningActive
+  actuator  uint8 PowerOptimizeLevel
+['Vehicle:Cabin:Infotainment:Media']
+  sensor    string DeclinedURI
+  actuator  string Action
+  actuator  string SelectedURI
+  actuator  uint8 Volume
+['Vehicle:Cabin:Infotainment:Media:Played']
+  sensor    string Artist
+  sensor    string Album
+  sensor    string Track
+  sensor    string URI
+  actuator  string Source
+  actuator  float PlaybackRate
+['Vehicle:Cabin:Infotainment:Navigation:DestinationSet']
+  actuator  double Latitude
+  actuator  double Longitude
+['Vehicle:Cabin:Infotainment:Navigation']
+  actuator  string Mute
+  actuator  uint8 Volume
+['Vehicle:Cabin:Infotainment:HMI']
+  sensor    string CurrentLanguage
+  actuator  string DateFormat
+  actuator  string TimeFormat
+  actuator  string DistanceUnit
+  actuator  string FuelVolumeUnit
+  actuator  string FuelEconomyUnits
+  actuator  string EVEconomyUnits
+  actuator  string TemperatureUnit
+  actuator  string TirePressureUnit
+  actuator  float Brightness
+  actuator  string DayNightMode
+['Vehicle:Cabin:Infotainment:SmartphoneProjection']
+  attribute string[] SupportedMode
+  actuator  string Active
+  actuator  string Source
+['Vehicle:Cabin:Infotainment']
+  actuator  uint8 PowerOptimizeLevel
+['Vehicle:Cabin:Sunroof']
+  sensor    int8 Position
+  actuator  string _Switch
+['Vehicle:Cabin:RearviewMirror']
+  actuator  uint8 DimmingLevel
+['Vehicle:Cabin:Lights']
+  sensor    uint8 AmbientLight
+  sensor    uint8 LightIntensity
+  actuator  boolean IsGloveBoxOn
+  actuator  boolean IsTrunkOn
+  actuator  boolean IsDomeOn
+['Vehicle:Cabin:Lights:Spotlight:Row1', 'Vehicle:Cabin:Lights:Spotlight:Row2', 'Vehicle:Cabin:Lights:Spotlight:Row3', 'Vehicle:Cabin:Lights:Spotlight:Row4']
+  sensor    boolean IsSharedOn
+  actuator  boolean IsLeftOn
+  actuator  boolean IsRightOn
+['Vehicle:Cabin:Door:Row1:Left', 'Vehicle:Cabin:Door:Row1:Right', 'Vehicle:Cabin:Door:Row2:Left', 'Vehicle:Cabin:Door:Row2:Right']
+  sensor    boolean IsChildLockActive
+  actuator  boolean IsOpen
+  actuator  boolean IsLocked
+['Vehicle:Cabin:Door:Row1:Left:Window', 'Vehicle:Cabin:Door:Row1:Right:Window', 'Vehicle:Cabin:Door:Row2:Left:Window', 'Vehicle:Cabin:Door:Row2:Right:Window']
+  sensor    boolean IsOpen
+  sensor    uint8 Position
+  sensor    boolean IsChildLockEngaged
+  actuator  string _Switch
+['Vehicle:Cabin']
+  attribute uint8 DoorCount
+  attribute uint8 DriverPosition
+  attribute uint8 SeatRowCount
+  attribute uint8[] SeatPosCount
+  actuator  uint8 PowerOptimizeLevel
+['Vehicle:Cabin:Seat:Row1:Pos1', 'Vehicle:Cabin:Seat:Row1:Pos2', 'Vehicle:Cabin:Seat:Row1:Pos3', 'Vehicle:Cabin:Seat:Row2:Pos1', 'Vehicle:Cabin:Seat:Row2:Pos2', 'Vehicle:Cabin:Seat:Row2:Pos3']
+  sensor    boolean IsOccupied
+  sensor    boolean IsBelted
+  actuator  int8 Heating
+  actuator  uint8 Massage
+  actuator  uint16 Position
+  actuator  uint16 Height
+  actuator  float Tilt
+['Vehicle:Cabin:Seat:Row1:Pos1:Occupant:Identifier', 'Vehicle:Cabin:Seat:Row1:Pos2:Occupant:Identifier', 'Vehicle:Cabin:Seat:Row1:Pos3:Occupant:Identifier', 'Vehicle:Cabin:Seat:Row2:Pos1:Occupant:Identifier', 'Vehicle:Cabin:Seat:Row2:Pos2:Occupant:Identifier', 'Vehicle:Cabin:Seat:Row2:Pos3:Occupant:Identifier', 'Vehicle:Driver:Identifier']
+  sensor    string Subject
+  sensor    string Issuer
+['Vehicle:Cabin:Seat:Row1:Pos1:Backrest', 'Vehicle:Cabin:Seat:Row1:Pos2:Backrest', 'Vehicle:Cabin:Seat:Row1:Pos3:Backrest', 'Vehicle:Cabin:Seat:Row2:Pos1:Backrest', 'Vehicle:Cabin:Seat:Row2:Pos2:Backrest', 'Vehicle:Cabin:Seat:Row2:Pos3:Backrest']
+  actuator  float Recline
+['Vehicle:Cabin:Seat:Row1:Pos1:Backrest:Lumbar', 'Vehicle:Cabin:Seat:Row1:Pos2:Backrest:Lumbar', 'Vehicle:Cabin:Seat:Row1:Pos3:Backrest:Lumbar', 'Vehicle:Cabin:Seat:Row2:Pos1:Backrest:Lumbar', 'Vehicle:Cabin:Seat:Row2:Pos2:Backrest:Lumbar', 'Vehicle:Cabin:Seat:Row2:Pos3:Backrest:Lumbar']
+  actuator  float Support
+  actuator  uint8 Height
+['Vehicle:Cabin:Seat:Row1:Pos1:Backrest:SideBolster', 'Vehicle:Cabin:Seat:Row1:Pos2:Backrest:SideBolster', 'Vehicle:Cabin:Seat:Row1:Pos3:Backrest:SideBolster', 'Vehicle:Cabin:Seat:Row2:Pos1:Backrest:SideBolster', 'Vehicle:Cabin:Seat:Row2:Pos2:Backrest:SideBolster', 'Vehicle:Cabin:Seat:Row2:Pos3:Backrest:SideBolster']
+  actuator  float Support
+['Vehicle:Cabin:Seat:Row1:Pos1:Seating', 'Vehicle:Cabin:Seat:Row1:Pos2:Seating', 'Vehicle:Cabin:Seat:Row1:Pos3:Seating', 'Vehicle:Cabin:Seat:Row2:Pos1:Seating', 'Vehicle:Cabin:Seat:Row2:Pos2:Seating', 'Vehicle:Cabin:Seat:Row2:Pos3:Seating']
+  actuator  uint16 Length
+['Vehicle:Cabin:Seat:Row1:Pos1:Headrest', 'Vehicle:Cabin:Seat:Row1:Pos2:Headrest', 'Vehicle:Cabin:Seat:Row1:Pos3:Headrest', 'Vehicle:Cabin:Seat:Row2:Pos1:Headrest', 'Vehicle:Cabin:Seat:Row2:Pos2:Headrest', 'Vehicle:Cabin:Seat:Row2:Pos3:Headrest']
+  actuator  uint8 Height
+  actuator  float Angle
+['Vehicle:Cabin:Seat:Row1:Pos1:Airbag', 'Vehicle:Cabin:Seat:Row1:Pos2:Airbag', 'Vehicle:Cabin:Seat:Row1:Pos3:Airbag', 'Vehicle:Cabin:Seat:Row2:Pos1:Airbag', 'Vehicle:Cabin:Seat:Row2:Pos2:Airbag', 'Vehicle:Cabin:Seat:Row2:Pos3:Airbag']
+  sensor    boolean IsDeployed
+['Vehicle:Cabin:Seat:Row1:Pos1:_Switch', 'Vehicle:Cabin:Seat:Row1:Pos2:_Switch', 'Vehicle:Cabin:Seat:Row1:Pos3:_Switch', 'Vehicle:Cabin:Seat:Row2:Pos1:_Switch', 'Vehicle:Cabin:Seat:Row2:Pos2:_Switch', 'Vehicle:Cabin:Seat:Row2:Pos3:_Switch']
+  actuator  boolean IsWarmerEngaged
+  actuator  boolean IsCoolerEngaged
+  actuator  boolean IsForwardEngaged
+  actuator  boolean IsBackwardEngaged
+  actuator  boolean IsUpEngaged
+  actuator  boolean IsDownEngaged
+  actuator  boolean IsTiltForwardEngaged
+  actuator  boolean IsTiltBackwardEngaged
+['Vehicle:Cabin:Seat:Row1:Pos1:_Switch:Backrest', 'Vehicle:Cabin:Seat:Row1:Pos2:_Switch:Backrest', 'Vehicle:Cabin:Seat:Row1:Pos3:_Switch:Backrest', 'Vehicle:Cabin:Seat:Row2:Pos1:_Switch:Backrest', 'Vehicle:Cabin:Seat:Row2:Pos2:_Switch:Backrest', 'Vehicle:Cabin:Seat:Row2:Pos3:_Switch:Backrest']
+  actuator  boolean IsReclineForwardEngaged
+  actuator  boolean IsReclineBackwardEngaged
+['Vehicle:Cabin:Seat:Row1:Pos1:_Switch:Backrest:Lumbar', 'Vehicle:Cabin:Seat:Row1:Pos2:_Switch:Backrest:Lumbar', 'Vehicle:Cabin:Seat:Row1:Pos3:_Switch:Backrest:Lumbar', 'Vehicle:Cabin:Seat:Row2:Pos1:_Switch:Backrest:Lumbar', 'Vehicle:Cabin:Seat:Row2:Pos2:_Switch:Backrest:Lumbar', 'Vehicle:Cabin:Seat:Row2:Pos3:_Switch:Backrest:Lumbar']
+  actuator  boolean IsMoreSupportEngaged
+  actuator  boolean IsLessSupportEngaged
+  actuator  boolean IsUpEngaged
+  actuator  boolean IsDownEngaged
+['Vehicle:Cabin:Seat:Row1:Pos1:_Switch:Backrest:SideBolster', 'Vehicle:Cabin:Seat:Row1:Pos2:_Switch:Backrest:SideBolster', 'Vehicle:Cabin:Seat:Row1:Pos3:_Switch:Backrest:SideBolster', 'Vehicle:Cabin:Seat:Row2:Pos1:_Switch:Backrest:SideBolster', 'Vehicle:Cabin:Seat:Row2:Pos2:_Switch:Backrest:SideBolster', 'Vehicle:Cabin:Seat:Row2:Pos3:_Switch:Backrest:SideBolster']
+  actuator  boolean IsMoreSupportEngaged
+  actuator  boolean IsLessSupportEngaged
+['Vehicle:Cabin:Seat:Row1:Pos1:_Switch:Seating', 'Vehicle:Cabin:Seat:Row1:Pos2:_Switch:Seating', 'Vehicle:Cabin:Seat:Row1:Pos3:_Switch:Seating', 'Vehicle:Cabin:Seat:Row2:Pos1:_Switch:Seating', 'Vehicle:Cabin:Seat:Row2:Pos2:_Switch:Seating', 'Vehicle:Cabin:Seat:Row2:Pos3:_Switch:Seating']
+  actuator  boolean IsForwardEngaged
+  actuator  boolean IsBackwardEngaged
+['Vehicle:Cabin:Seat:Row1:Pos1:_Switch:Headrest', 'Vehicle:Cabin:Seat:Row1:Pos2:_Switch:Headrest', 'Vehicle:Cabin:Seat:Row1:Pos3:_Switch:Headrest', 'Vehicle:Cabin:Seat:Row2:Pos1:_Switch:Headrest', 'Vehicle:Cabin:Seat:Row2:Pos2:_Switch:Headrest', 'Vehicle:Cabin:Seat:Row2:Pos3:_Switch:Headrest']
+  actuator  boolean IsUpEngaged
+  actuator  boolean IsDownEngaged
+  actuator  boolean IsForwardEngaged
+  actuator  boolean IsBackwardEngaged
+['Vehicle:Cabin:Seat:Row1:Pos1:_Switch:Massage', 'Vehicle:Cabin:Seat:Row1:Pos2:_Switch:Massage', 'Vehicle:Cabin:Seat:Row1:Pos3:_Switch:Massage', 'Vehicle:Cabin:Seat:Row2:Pos1:_Switch:Massage', 'Vehicle:Cabin:Seat:Row2:Pos2:_Switch:Massage', 'Vehicle:Cabin:Seat:Row2:Pos3:_Switch:Massage']
+  actuator  boolean IsIncreaseEngaged
+  actuator  boolean IsDecreaseEngaged
+['Vehicle:Cabin:Convertible']
+  sensor    string Status
+['Vehicle:ADAS']
+  attribute string SupportedAutonomyLevel
+  sensor    string ActiveAutonomyLevel
+  actuator  uint8 PowerOptimizeLevel
+['Vehicle:ADAS:CruiseControl']
+  sensor    boolean IsError
+  actuator  boolean IsEnabled
+  actuator  boolean IsActive
+  actuator  float SpeedSet
+['Vehicle:ADAS:LaneDepartureDetection', 'Vehicle:ADAS:ObstacleDetection']
+  sensor    boolean IsWarning
+  sensor    boolean IsError
+  actuator  boolean IsEnabled
+['Vehicle:ADAS:ABS', 'Vehicle:ADAS:TCS', 'Vehicle:ADAS:EBD', 'Vehicle:ADAS:EBA']
+  sensor    boolean IsError
+  sensor    boolean IsEngaged
+  actuator  boolean IsEnabled
+['Vehicle:ADAS:ESC']
+  sensor    boolean IsError
+  sensor    boolean IsEngaged
+  sensor    boolean IsStrongCrossWindDetected
+  actuator  boolean IsEnabled
+['Vehicle:ADAS:ESC:RoadFriction']
+  sensor    float MostProbable
+  sensor    float LowerBound
+  sensor    float UpperBound
+['Vehicle:Chassis']
+  attribute uint16 Wheelbase
+  attribute uint16 Track
+  attribute uint8 AxleCount
+['Vehicle:Chassis:Axle:Row1', 'Vehicle:Chassis:Axle:Row2']
+  attribute uint8 WheelCount
+  attribute float WheelDiameter
+  attribute float WheelWidth
+  attribute float TireDiameter
+  attribute uint16 TireWidth
+  attribute uint8 TireAspectRatio
+  sensor    float SteeringAngle
+['Vehicle:Chassis:Axle:Row1:Wheel:Left:Brake', 'Vehicle:Chassis:Axle:Row1:Wheel:Right:Brake', 'Vehicle:Chassis:Axle:Row2:Wheel:Left:Brake', 'Vehicle:Chassis:Axle:Row2:Wheel:Right:Brake']
+  sensor    uint8 FluidLevel
+  sensor    boolean IsFluidLevelLow
+  sensor    uint8 PadWear
+  sensor    boolean IsBrakesWorn
+['Vehicle:Chassis:Axle:Row1:Wheel:Left:Tire', 'Vehicle:Chassis:Axle:Row1:Wheel:Right:Tire', 'Vehicle:Chassis:Axle:Row2:Wheel:Left:Tire', 'Vehicle:Chassis:Axle:Row2:Wheel:Right:Tire']
+  sensor    uint16 Pressure
+  sensor    boolean IsPressureLow
+  sensor    float Temperature
+['Vehicle:Chassis:Axle:Row1:Wheel:Left', 'Vehicle:Chassis:Axle:Row1:Wheel:Right', 'Vehicle:Chassis:Axle:Row2:Wheel:Left', 'Vehicle:Chassis:Axle:Row2:Wheel:Right']
+  sensor    float Speed
+['Vehicle:Chassis:ParkingBrake']
+  actuator  boolean IsEngaged
+  actuator  boolean IsAutoApplyEnabled
+['Vehicle:Chassis:SteeringWheel']
+  attribute string Position
+  sensor    int16 Angle
+  actuator  uint8 Tilt
+  actuator  uint8 Extension
+['Vehicle:Chassis:Accelerator']
+  sensor    uint8 PedalPosition
+['Vehicle:Chassis:Brake']
+  sensor    uint8 PedalPosition
+  sensor    boolean IsDriverEmergencyBrakingDetected
+['Vehicle:OBD']
+  attribute uint8 OBDStandards
+  sensor    uint32 PidsA
+  sensor    string[] DTCList
+  sensor    string FreezeDTC
+  sensor    string FuelStatus
+  sensor    float EngineLoad
+  sensor    float CoolantTemperature
+  sensor    float ShortTermFuelTrim1
+  sensor    float LongTermFuelTrim1
+  sensor    float ShortTermFuelTrim2
+  sensor    float LongTermFuelTrim2
+  sensor    float FuelPressure
+  sensor    float _MAP
+  sensor    float EngineSpeed
+  sensor    float Speed
+  sensor    float TimingAdvance
+  sensor    float IntakeTemp
+  sensor    float MAF
+  sensor    float ThrottlePosition
+  sensor    string AirStatus
+  sensor    uint8 OxygenSensorsIn2Banks
+  sensor    uint8 OxygenSensorsIn4Banks
+  sensor    boolean IsPTOActive
+  sensor    float RunTime
+  sensor    uint32 PidsB
+  sensor    float DistanceWithMIL
+  sensor    float FuelRailPressureVac
+  sensor    float FuelRailPressureDirect
+  sensor    float CommandedEGR
+  sensor    float EGRError
+  sensor    float CommandedEVAP
+  sensor    float FuelLevel
+  sensor    uint8 WarmupsSinceDTCClear
+  sensor    float DistanceSinceDTCClear
+  sensor    float EVAPVaporPressure
+  sensor    float BarometricPressure
+  sensor    uint32 PidsC
+  sensor    float ControlModuleVoltage
+  sensor    float AbsoluteLoad
+  sensor    float CommandedEquivalenceRatio
+  sensor    float RelativeThrottlePosition
+  sensor    float AmbientAirTemperature
+  sensor    float ThrottlePositionB
+  sensor    float ThrottlePositionC
+  sensor    float AcceleratorPositionD
+  sensor    float AcceleratorPositionE
+  sensor    float AcceleratorPositionF
+  sensor    float ThrottleActuator
+  sensor    float RunTimeMIL
+  sensor    float TimeSinceDTCCleared
+  sensor    float MaxMAF
+  sensor    string FuelType
+  sensor    float EthanolPercent
+  sensor    float EVAPVaporPressureAbsolute
+  sensor    float EVAPVaporPressureAlternate
+  sensor    float ShortTermO2Trim1
+  sensor    float ShortTermO2Trim3
+  sensor    float LongTermO2Trim1
+  sensor    float LongTermO2Trim3
+  sensor    float ShortTermO2Trim2
+  sensor    float ShortTermO2Trim4
+  sensor    float LongTermO2Trim2
+  sensor    float LongTermO2Trim4
+  sensor    float FuelRailPressureAbsolute
+  sensor    float RelativeAcceleratorPosition
+  sensor    float HybridBatteryRemaining
+  sensor    float OilTemperature
+  sensor    float FuelInjectionTiming
+  sensor    float FuelRate
+['Vehicle:OBD:Status', 'Vehicle:OBD:DriveCycleStatus']
+  sensor    boolean IsMILOn
+  sensor    uint8 DTCCount
+  sensor    string IgnitionType
+['Vehicle:OBD:O2:Sensor1', 'Vehicle:OBD:O2:Sensor2', 'Vehicle:OBD:O2:Sensor3', 'Vehicle:OBD:O2:Sensor4', 'Vehicle:OBD:O2:Sensor5', 'Vehicle:OBD:O2:Sensor6', 'Vehicle:OBD:O2:Sensor7', 'Vehicle:OBD:O2:Sensor8']
+  sensor    float Voltage
+  sensor    float ShortTermFuelTrim
+['Vehicle:OBD:O2WR:Sensor1', 'Vehicle:OBD:O2WR:Sensor2', 'Vehicle:OBD:O2WR:Sensor3', 'Vehicle:OBD:O2WR:Sensor4', 'Vehicle:OBD:O2WR:Sensor5', 'Vehicle:OBD:O2WR:Sensor6', 'Vehicle:OBD:O2WR:Sensor7', 'Vehicle:OBD:O2WR:Sensor8']
+  sensor    float Lambda
+  sensor    float Voltage
+  sensor    float Current
+['Vehicle:OBD:Catalyst:Bank1', 'Vehicle:OBD:Catalyst:Bank2']
+  sensor    float Temperature1
+  sensor    float Temperature2
+['Vehicle:Driver']
+  sensor    float DistractionLevel
+  sensor    boolean IsEyesOnRoad
+  sensor    float AttentiveProbability
+  sensor    float FatigueLevel
+  sensor    uint16 HeartRate
+['Vehicle:Exterior']
+  sensor    float AirTemperature
+  sensor    float Humidity
+  sensor    float LightIntensity
+['Vehicle:Service']
+  sensor    boolean IsServiceDue
+  sensor    float DistanceToService
+  sensor    int32 TimeToService
+['Vehicle:Connectivity']
+  sensor    boolean IsConnectivityAvailable


### PR DESCRIPTION
Proposal to add new keywords to VSS, and format specification documents to vss-tools.
From these, the exporter modules in vss-tools can be modified to take advantage of the new keywords to produce output that conforms to the format specification documents.   First use case is for IDL, but the intent is to benefit other export formats as well.
The specifics of the grouping of every VSS signal is 'to be determined', enabled by the new keywords.
This effort has been separate and in parallel with https://github.com/COVESA/vss-tools/pull/262 -- but working toward a common goal.
(note that some changes in this PR are trivial doc changes; ignore)
Signed-off-by: Neil Puthuff <neil@rti.com>