### PR TITLE
Add FontSize property to HMI branch and GuidanceVoice property to Navigation branch

### DIFF
--- a/spec/Cabin/Infotainment.vspec
+++ b/spec/Cabin/Infotainment.vspec
@@ -122,6 +122,12 @@ HMI.CurrentLanguage:
   type: sensor
   description: ISO 639-1 standard language code for the current HMI
 
+HMI.FontSize:
+  datatype: string
+  type: actuator
+  allowed: ['STANDARD', 'LARGE', 'EXTRA_LARGE']
+  description: Font size used in the current HMI
+
 HMI.DateFormat:
   datatype: string
   type: actuator

--- a/spec/Cabin/Infotainment.vspec
+++ b/spec/Cabin/Infotainment.vspec
@@ -113,6 +113,12 @@ Navigation.Volume:
   unit: percent
   description: Current navigation volume
 
+Navigation.GuidanceVoice:
+  datatype: string
+  type: actuator
+  allowed: ['STANDARD_MALE', 'STANDARD_FEMALE', 'ETC']
+  description: Navigation guidance state that was selected.
+
 HMI:
   type: branch
   description: HMI related signals

--- a/spec/Cabin/Infotainment.vspec
+++ b/spec/Cabin/Infotainment.vspec
@@ -118,6 +118,7 @@ Navigation.GuidanceVoice:
   type: actuator
   allowed: ['STANDARD_MALE', 'STANDARD_FEMALE', 'ETC']
   description: Navigation guidance state that was selected.
+  comment: ETC indicates a voice alternative not covered by the explicitly listed alternatives.
 
 HMI:
   type: branch


### PR DESCRIPTION
- For HMI, FontSize property might be required to enhance readability and improve the user experience for drivers and passengers.
- For navigation features, GuidanceVoice property might be required to enhance the user experience on the car