### PR TITLE
Driver/steering position issues

### DIFF
--- a/spec/Cabin/Cabin.vspec
+++ b/spec/Cabin/Cabin.vspec
@@ -155,9 +155,8 @@ DriverPosition:
   datatype: string
   type: attribute
   allowed: ['LEFT', 'MIDDLE', 'RIGHT']
-  default: 'LEFT'
   description: The position of the driver seat in row 1.
-  comment: Default value is position 'LEFT', i.e. a typical LHD vehicle. Some signals use DriverSide and PassengerSide as instances. If this signal specifies that DriverPosition is LEFT or MIDDLE, then DriverSide refers to left side and PassengerSide to right side. If this signal specifies that DriverPosition is RIGHT, then DriverSide refers to right side and PassengerSide to left side.
+  comment: Some signals use DriverSide and PassengerSide as instances. If this signal specifies that DriverPosition is LEFT or MIDDLE, then DriverSide refers to left side and PassengerSide to right side. If this signal specifies that DriverPosition is RIGHT, then DriverSide refers to right side and PassengerSide to left side.
 
 SeatRowCount:
   datatype: uint8

--- a/spec/Chassis/Chassis.vspec
+++ b/spec/Chassis/Chassis.vspec
@@ -167,13 +167,6 @@ SteeringWheel.Extension:
   unit: percent
   description: Steering wheel column extension from dashboard. 0 = Closest to dashboard. 100 = Furthest from dashboard.
 
-SteeringWheel.Position:
-  datatype: string
-  type: attribute
-  default: 'FRONT_LEFT'
-  allowed: ['FRONT_LEFT', 'FRONT_RIGHT']
-  description: Position of the steering wheel on the left or right side of the vehicle.
-
 #
 # Accelerator
 #


### PR DESCRIPTION
This PR addresses two identified issues:

1. Vehicle.Cabin.DriverPosition values can be 'LEFT', 'MIDDLE', 'RIGHT'. However, Vehicle.Chassis.SteeringWheel.Position can only be 'FRONT_LEFT', 'FRONT_RIGHT', meaning that there is a possibility that the steering position and driver position cannot be set the same when the driver/steering position is in the middle. 
 - Suggested fix: Remove Vehicle.Chassis.SteeringWheel.Position entirely, since this is an overlap with Vehicle.Cabin.DriverPosition.
 - Cleanest solution, especially since in VSS v4.0 we don’t have to worry about backwards incompatibility.
 - Note: There are other leaf nodes under the Vehicle.Chassis.SteeringWheel branch that should of course remain

2. Vehicle.Cabin.DriverPosition default value is ‘LEFT’. However, it is unclear why this needs a default value since other signals that are restricted to Allowed Values do not have a Default Value specified. Furthermore, specifying a default of ‘LEFT’ increases the chances of right-hand drive vehicles being misconfigured (e.g. because the implementer forgot to actually assign it a specific value), which could affect up to 54 of 195 UN recognised countries (see https://en.wikipedia.org/wiki/Left-_and_right-hand_traffic#Worldwide_distribution_by_country). In a worse case scenario, such a misconfiguration could wrongly infer to national authorities that the vehicle is illegal in that country due to some countries prohibiting registration of vehicles with steering wheels on the “wrong side” of the vehicle (see https://en.wikipedia.org/wiki/Left-_and_right-hand_traffic#Legality_of_wrong-hand-drive_vehicles_by_country).
- Suggested fix: Remove default value of Vehicle.Cabin.DriverPosition.
- This then gives better assurance of correct vehicle configuration by forcing implementers to actually set this value in their deployments rather than (possibly inadvertently) relying on a default value which will be wrong in at least 28% of UN recognised countries, as well as in vehicles whose steering is located in the middle (e.g. some sports cars, motorbikes/mopeds, etc). A blank/null value is easily caught in testing and therefore can be rectified early.