### PR TITLE
Add missing units to various signals

### DIFF
--- a/spec/Body/Body.vspec
+++ b/spec/Body/Body.vspec
@@ -130,6 +130,7 @@ Windshield.Wiping.System:
 Windshield.Wiping.WiperWear:
   datatype: uint8
   type: sensor
+  unit: percent
   max: 100
   description: Wiper wear as percent.
                0 = No Wear.

--- a/spec/Body/WiperSystem.vspec
+++ b/spec/Body/WiperSystem.vspec
@@ -56,6 +56,7 @@ Mode:
 
 Frequency:
   datatype: uint8
+  unit: cpm
   type: actuator
   description: Wiping frequency/speed, measured in cycles per minute.
                The signal concerns the actual speed of the wiper blades when moving.

--- a/spec/Cabin/Cabin.vspec
+++ b/spec/Cabin/Cabin.vspec
@@ -49,6 +49,7 @@ Sunroof:
 Sunroof.Position:
   datatype: int8
   type: sensor
+  unit: percent
   min: -100
   max: 100
   description: Sunroof position. 0 = Fully closed 100 = Fully opened. -100 = Fully tilted.

--- a/spec/Driver/Driver.vspec
+++ b/spec/Driver/Driver.vspec
@@ -48,4 +48,5 @@ FatigueLevel:
 HeartRate:
   datatype: uint16
   type: sensor
+  unit: bpm
   description: Heart rate of the driver.

--- a/spec/units.yaml
+++ b/spec/units.yaml
@@ -218,3 +218,11 @@ units:
     label: kilo newton
     description: Force measured in kilo newton
     domain: force
+  cpm:
+    label: cycles per minute
+    description: Number of cycles per minute
+    domain: frequency
+  bpm:
+    label: beats per minute
+    description: Number of human heart beats per minute
+    domain: frequency


### PR DESCRIPTION
This PR addresses the following issues related to the Units of some signals:

1. Vehicle.Driver.HeartRate is missing a defined Unit.
 - Suggested fix: Set Unit to “bpm” (beats per minute) and add to Units config file.

2. Vehicle.Cabin.Sunroof.Position is missing a defined Unit.
 - Suggested fix: Set Unit to “percent”.

3. Vehicle.Body.Windshield.Front.Wiping.WiperWear and Vehicle.Body.Windshield.Rear.Wiping.WiperWear are missing a Unit.
 - Suggested fix: Set Unit to “percent”.

4. Vehicle.Body.Windshield.Front.Wiping.System.Frequency and Vehicle.Body.Windshield.Rear.Wiping.System.Frequency missing Unit. Description states the value is “cycles per minute”.
 - Suggested fix: Set Unit to “cpm” (cycles per minute) and add to Units config file.
