### PR TITLE
Removal of deprecated signals from VSS v3.1

### DIFF
--- a/spec/Powertrain/FuelSystem.vspec
+++ b/spec/Powertrain/FuelSystem.vspec
@@ -86,13 +86,6 @@ ConsumptionSinceStart:
            A trip is considered to end when engine is no longer enabled.
            The signal may however keep the value of the last trip until a new trip is started.
 
-TimeSinceStart:
-  deprecation: V3.1 replaced by Vehicle.StartTime and Vehicle.TripDuration
-  datatype: uint32
-  type: sensor
-  unit: s
-  description: Time in seconds elapsed since start of current trip.
-
 IsEngineStopStartEnabled:
   datatype: boolean
   type: sensor

--- a/spec/Vehicle/Vehicle.vspec
+++ b/spec/Vehicle/Vehicle.vspec
@@ -188,13 +188,6 @@ Speed:
   unit: km/h
   description: Vehicle speed.
 
-TravelledDistance:
-  deprecation: V3.1 moved to Vehicle.TraveledDistance
-  datatype: float
-  type: sensor
-  unit: km
-  description: Odometer reading, total distance traveled during the lifetime of the vehicle.
-
 TraveledDistance:
   datatype: float
   type: sensor


### PR DESCRIPTION
Two signals were listed as deprecated in VSS v3.1: Vehicle.TravelledDistance and Vehicle.Powertrain.FuelSystem.TimeSinceStart. Therefore, since the current (in-development) version is a major release (v4.0), these two signals should not appear.