### PR TITLE
Miscellaneous editorial only corrections

### DIFF
--- a/spec/Body/Body.vspec
+++ b/spec/Body/Body.vspec
@@ -84,7 +84,7 @@ Horn.IsActive:
 #
 Raindetection:
   type: branch
-  description: Rainsensor signals.
+  description: Rain sensor signals.
 
 Raindetection.Intensity:
   datatype: uint8

--- a/spec/Cabin/Cabin.vspec
+++ b/spec/Cabin/Cabin.vspec
@@ -71,18 +71,18 @@ Sunroof.Shade:
 #include SingleShade.vspec Sunroof.Shade
 
 #
-# Rearview mirror signals
+# Rear-view mirror signals
 #
 RearviewMirror:
   type: branch
-  description: Rearview mirror.
+  description: Rear-view mirror.
 
 RearviewMirror.DimmingLevel:
   datatype: uint8
   type: actuator
   unit: percent
   max: 100
-  description: Dimming level of rearview mirror. 0 = undimmed. 100 = fully dimmed.
+  description: Dimming level of rear-view mirror. 0 = Undimmed. 100 = Fully dimmed.
 
 
 ##

--- a/spec/Cabin/InteriorLights.vspec
+++ b/spec/Cabin/InteriorLights.vspec
@@ -22,7 +22,7 @@ IsGloveBoxOn:
 IsDomeOn:
   datatype: boolean
   type: actuator
-  description: Is central dome light light on
+  description: Is central dome light on
 
 PerceivedAmbientLight:
   datatype: uint8
@@ -50,16 +50,16 @@ AmbientLight:
   instances:
     - Row[1,2]
     - ["DriverSide","PassengerSide"]
-  description: Decorative coloured light inside the cabin, usually mounted on the door, cealing, etc.
+  description: Decorative coloured light inside the cabin, usually mounted on the door, ceiling, etc.
 #include SingleConfigurableLight.vspec AmbientLight
 
 InteractiveLightBar:
   type: branch
-  description: Decorative coloured light bar that supports effects. It is usually mounted on the dashboard (e.g., BMW i7 Interactive bar).
+  description: Decorative coloured light bar that supports effects, usually mounted on the dashboard (e.g. BMW i7 Interactive bar).
 #include SingleConfigurableLight.vspec InteractiveLightBar
 
 InteractiveLightBar.Effect:
   type: actuator
   datatype: string
   description: Light effect selection from a predefined set of allowed values.
-  comment: Default and allowed values are OEM-specific and should be defined accordingly (e.g., with the use of overlays).
+  comment: Default and allowed values are OEM-specific and should be defined accordingly (e.g. with the use of overlays).

--- a/spec/Cabin/SingleConfigurableLight.vspec
+++ b/spec/Cabin/SingleConfigurableLight.vspec
@@ -20,11 +20,11 @@ Intensity:
   unit: percent
   min: 1
   max: 100
-  description: How much of the maximum possible brightness of the light is used. 1 = Maximum attenuation, 100 = no attenuation (i.e., full brightness).
+  description: How much of the maximum possible brightness of the light is used. 1 = Maximum attenuation, 100 = No attenuation (i.e. full brightness).
   comment: Minimum value cannot be zero as on/off is controlled by the actuator IsLightOn. V4.0 moved from Cabin.Lights.AmbientLight.Intensity to enable individual control of lights via the SingleConfigurableLight.vspec.
 
 Color:
   type: actuator
   datatype: string
-  description: Hexadecimal color code represented as a 3-byte RGB (i.e., Red, Green, and Blue) value preceded by a hash symbol "#". Allowed range "#000000" to "#FFFFFF".
+  description: Hexadecimal color code represented as a 3-byte RGB (i.e. Red, Green, and Blue) value preceded by a hash symbol "#". Allowed range "#000000" to "#FFFFFF".
   comment: For example; "#C0C0C0" = Silver, "#FFD700" = Gold, "#000000" = Black, "#FFFFFF" = White, etc.

--- a/spec/Chassis/Chassis.vspec
+++ b/spec/Chassis/Chassis.vspec
@@ -15,7 +15,7 @@ Wheelbase:
   type: attribute
   default: 0
   unit: mm
-  description: Overall wheel base, in mm.
+  description: Overall wheelbase, in mm.
 
 
 #

--- a/spec/Driver/Driver.vspec
+++ b/spec/Driver/Driver.vspec
@@ -17,7 +17,7 @@ DistractionLevel:
   unit: percent
   min: 0
   max: 100
-  description: Distraction level of the driver will be the level how much the driver is distracted, by multiple factors. E.g. Driving situation, acustical or optical signales inside the cockpit, phone calls.
+  description: Distraction level of the driver, which can be evaluated by multiple factors e.g. driving situation, acoustical or optical signals inside the cockpit, ongoing phone calls.
 
 IsEyesOnRoad:
   datatype: boolean
@@ -43,7 +43,7 @@ FatigueLevel:
   unit: percent
   min: 0
   max: 100
-  description: Fatigueness level of driver. Evaluated by multiple factors like trip time, behaviour of steering, eye status.
+  description: Fatigue level of the driver, which can be evaluated by multiple factors e.g. trip time, behaviour of steering, eye status.
 
 HeartRate:
   datatype: uint16

--- a/spec/Identifier/Identifier.vspec
+++ b/spec/Identifier/Identifier.vspec
@@ -12,9 +12,9 @@
 Subject:
   datatype: string
   type: sensor
-  description: Subject for the authentication of the occupant. E.g. UserID 7331677.
+  description: Subject for the authentication of the occupant e.g. UserID 7331677.
 
 Issuer:
   datatype: string
   type: sensor
-  description: Unique Issuer for the authentication of the occupant. E.g. https://accounts.funcorp.com.
+  description: Unique Issuer for the authentication of the occupant e.g. https://accounts.funcorp.com.

--- a/spec/Powertrain/Battery.vspec
+++ b/spec/Powertrain/Battery.vspec
@@ -294,7 +294,7 @@ Charging.Mode:
   description: Control of the charge process.
                MANUAL means manually initiated (plug-in event, companion app, etc).
                TIMER means timer-based.
-               GRID means grid-controlled (eg ISO 15118).
+               GRID means grid-controlled (e.g. ISO 15118).
                PROFILE means controlled by profile download to vehicle.
   comment:     The mechanism to provide a profile to the vehicle is currently not covered by VSS.
 

--- a/spec/Vehicle/Vehicle.vspec
+++ b/spec/Vehicle/Vehicle.vspec
@@ -226,7 +226,7 @@ TripDuration:
   unit: s
   description: Duration of latest trip.
   comment: This signal is not assumed to be continuously updated, but instead set to 0 when a trip starts
-           and set to the the actual duration of the trip when a trip ends.
+           and set to the actual duration of the trip when a trip ends.
            A new trip is considered to start when engine gets enabled (e.g. LowVoltageSystemState in ON or START mode).
            A trip is considered to end when engine is no longer enabled.
 


### PR DESCRIPTION
Editorial-only corrections to text in Description and Comment fields of various signals and branches. Summary:
- Change of "rainsensor" into two words (no such word as "rainsensor")
- Change of "Rearview mirror" to "Rear-view mirror" (no such word as "rearview", needs hyphenating as it's a compound adjective)
- Change of "Wheel base" to "Wheelbase"
- Correction to spelling of "ceiling" (was "cealing" in some instances)
- Removal of some instances of duplicate words
- Overhaul and alignment of Description texts for DistractionLevel and FatigueLevel
- Numerous corrections to case of letters and fixes to instances of "e.g." and "i.e."

Nick Russell <79584907+nickrbb@users.noreply.github.com>