### PR TITLE
VSS 4.0: Verify that ddsidl is correct

### DIFF
--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -43,6 +43,14 @@ jobs:
           PIPENV_PIPFILE: ./vss-tools/Pipfile
           PIPENV_VENV_IN_PROJECT: 1
 
+      - name: Test that ddsidl is correct
+        run: |
+          pipenv install cyclonedds
+          pipenv run idlc *.idl
+        env:
+          PIPENV_PIPFILE: ./vss-tools/Pipfile
+          PIPENV_VENV_IN_PROJECT: 1
+
       - name: Test optional targets. NOTE - always succeeds
         run: |
           pipenv install

--- a/spec/Cabin/Infotainment.vspec
+++ b/spec/Cabin/Infotainment.vspec
@@ -113,6 +113,13 @@ Navigation.Volume:
   unit: percent
   description: Current navigation volume
 
+Navigation.GuidanceVoice:
+  datatype: string
+  type: actuator
+  allowed: ['STANDARD_MALE', 'STANDARD_FEMALE', 'ETC']
+  description: Navigation guidance state that was selected.
+  comment: ETC indicates a voice alternative not covered by the explicitly listed alternatives.
+
 HMI:
   type: branch
   description: HMI related signals
@@ -121,6 +128,12 @@ HMI.CurrentLanguage:
   datatype: string
   type: sensor
   description: ISO 639-1 standard language code for the current HMI
+
+HMI.FontSize:
+  datatype: string
+  type: actuator
+  allowed: ['STANDARD', 'LARGE', 'EXTRA_LARGE']
+  description: Font size used in the current HMI
 
 HMI.DateFormat:
   datatype: string


### PR DESCRIPTION
This is intended to catch the syntax error currently existing

I.e. that build fails is expected until vss-tools PR https://github.com/COVESA/vss-tools/pull/277 is merged and submodule reference updated