### PR TITLE
Improving documentation on how to use Makefile

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,80 @@
+# Building and Using the VSS Standard Catalog
+
+As a VSS user you have two options - either your project directly consumes the source files (`*.vspec`) in this repository,
+or you first convert it to some other format using [VSS Tools](https://github.com/COVESA/vss-tools).
+
+## Using the VSS source files
+
+If you intend to write your own VSS parser there are two files that you need to use as input.
+The root source file for the VSS standard catalog is [VehicleSignalSpecification.vspec](spec/VehicleSignalSpecification.vspec).
+It include all other `*.vspec` files in this repository (except overlays/profiles).
+Your parser may also be interested in using the [units.yaml](spec/units.yaml) file that list all units defined by the
+standard catalog documentation.
+
+## Using VSS-Tools
+
+Before writing your own parser it could be an idea to check if a suitable parser already has been created as part of
+[VSS-Tools](https://github.com/COVESA/vss-tools). This repository use some of the tools in VSS-Tools during Continuous
+Integration, and we also provide generated artifacts (CSV, Franca IDL, Graphql, DDS IDL, JSON, Yaml) for each
+[release](https://github.com/COVESA/vehicle_signal_specification/releases).
+The sections below provide some guidance on how to use VSS-Tools to convert the VSS standard catalog.
+Before creating a Pull Requst towards this repository it is recommended that you verify that your modified catalog
+can be used successfully with tools used in continuous integration.
+
+For detailed information on development environment and usage see [VSS-Tools](https://github.com/COVESA/vss-tools).
+
+### Set up you development environment
+
+You are free to use whatever development environment you want, but tools in [VSS-tools](https://github.com/COVESA/vss-tools)
+have typically been tested only on Linux, and in continuous integration "ubuntu-latest" is used for testing.
+
+For development a typical workflow to set up the development environment is as follows:
+
+1. Clone the [VSS repository](https://github.com/COVESA/vehicle_signal_specification
+2. Get all submodules (`git submodule update --init`)
+3. Follow instructions in [VSS-tools](https://github.com/COVESA/vss-tools/blob/master/README.md) to install dependencies
+4. Verify that your development environment is fully functional by running `make` from your `vehicle_signal_specification` folder.
+
+### Generating artifacts
+
+If you want to generate VSS artifacts (JSON, CSV, ...) similar to what is included in
+[VSS-releases](https://github.com/COVESA/vehicle_signal_specification/releases) you can do that with `make`.
+Check the [Makefile](Makefile) for available commands.
+
+An example to generate CSV from the *.vspec files in your current branch is:
+
+```
+user@debian:~/vehicle_signal_specification$ make csv
+./vss-tools/vspec2csv.py -I ./spec --uuid -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss_rel_$(cat VERSION).csv
+INFO     Output to csv format
+INFO     Known extended attributes:
+INFO     Added 56 units from ./spec/units.yaml
+INFO     Loading vspec from ./spec/VehicleSignalSpecification.vspec...
+INFO     Calling exporter...
+INFO     Generating CSV output...
+INFO     All done.
+user@debian:~/vehicle_signal_specification$ ls *.csv
+vss_rel_4.1-dev.csv
+```
+
+### Make sure that your changes pass CI checks
+
+Continuous Integration (CI) checks are defined in the [workflows](.github/workflows) folder.
+They consist of the following areas
+
+#### Signoff
+All commits must be signed-off, see [CONTRIBUTING.md](CONTRIBUTING.md)
+
+#### Build checks
+Make sure that `make travis-targets` succeeds. It is even better if all targets succeed (`make all`).
+
+#### Pre-commit checks
+The repository has [configuration file](.pre-commit-config.yaml) with pre-commits hooks.
+It executes a number of checks that typically must pass for a new Pull Request to be accepted and merged.
+You must manually configure pre-commit to use the provided hooks by running `pre-commit install` from the
+respository top folder.
+
+```bash
+~/vehicle_signal_specification$: pip install pre-commit
+~/vehicle_signal_specification$: pre-commit install
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,15 +26,15 @@ This is the typical workflow for preparing a pull request. A Github account is r
 1. Create a personal or company fork of the [VSS repository](https://github.com/COVESA/vehicle_signal_specification)
    and/or [VSS-Tools repository](https://github.com/COVESA/vss-tools).
 2. Clone the forked repository into your local development environment.
-3. Create a local branch based on the VSS master branch to use for the proposed changes.
-4. Introduce the wanted changes or extensions in your local development environment, see guidelines below.
+3. Set up your local development environment, see [BUILD.md](BUILD.md) for some guidance.
+4. Create a local branch based on the VSS master branch to use for the proposed changes.
+5. Introduce the wanted changes or extensions in your local development environment, see guidelines below.
    If you want change/extend VSS-signals, it is the *.vspec files in the [spec](https://github.com/COVESA/vehicle_signal_specification/tree/master/spec) folder that
    needs to be updated.
-5. Run "make travis_targets" to verify that the changes are syntactically correct and does not introduce any side effects.
-   This will verify that tools and test-cases in vss-tools repository accepts the changes.
-6. Create a commit and upload to your own fork.
-7. In the GitHub UI create a Pull Request from your fork to the master branch of [the VSS repository](https://github.com/COVESA/vehicle_signal_specification).
-8. Validate that automatic build checks for the PR succeed.
+6. Verify that your changes fulfil VSS Continuous Integration requirements, see [BUILD.md](BUILD.md) for some guidance.
+7. Create a commit and upload to your own fork.
+8. In the GitHub UI create a Pull Request from your fork to the master branch of [the VSS repository](https://github.com/COVESA/vehicle_signal_specification).
+9. Validate that automatic build checks for the PR succeed.
 
 ## Handling of the created Pull Request
 
@@ -57,7 +57,7 @@ COVESA has defined [contribution guidelines](https://www.covesa.global/contribut
 
 Every contribution must carry the following sign-off line with your real name and email address:
 
-`Signed-off-by: Firstname Lastname <firstname.lastname@example.com>`
+`Signed-off-by: Firstname Lastname <you@example.com>`
 
 By supplying this sign-off line, you indicate your acceptance of the COVESA Certificate of Origin.
 
@@ -98,6 +98,7 @@ Try to reuse the same style as used for existing signals.
 Only specify min/max-values if there is a logical reason to limit the range.
 Boolean signals should start with `Is*`.
 American English is preferred over British English.
+No trailing blanks.
 Follow the style guide in the [documentation](https://covesa.github.io/vehicle_signal_specification/rule_set/basics/#style-guide).
 
 ### No scaling, SI-unit, natural datatype
@@ -108,18 +109,6 @@ see [documentation](https://covesa.github.io/vehicle_signal_specification/rule_s
 If it is unlikely that someone is interested in decimals for this value, select a signed or unsigned integer type.
 Select a size which with reasonable margins can cover all vehicles.
 If it is likely that decimal values are needed select float or if relevant double.
-
-### Use the repository pre-commit hook
-
-The repository has [configuration file](.pre-commit-config.yaml) with pre-commits hooks.
-It executes a number of checks that typically must pass for a new Pull Request to be accepted and merged.
-You must manually configure pre-commit to use the provided hooks by running `pre-commit install` from the
-respository top folder.
-
-```bash
-~/vehicle_signal_specification$: pip install pre-commit
-~/vehicle_signal_specification$: pre-commit install
-```
 
 ### Avoid backward incompatible changes
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License](https://img.shields.io/badge/License-MPL%202.0-blue.svg)](https://opensource.org/licenses/MPL-2.0)
 [![Build Status](https://github.com/COVESA/vehicle_signal_specification/actions/workflows/buildcheck.yml/badge.svg)](https://github.com/COVESA/vehicle_signal_specification/actions/workflows/buildcheck.yml?query=branch%3Amaster)
 
-The overall goal of the Vehicle Signal Specification (VSS)  is to create a common understanding of vehicle signals in order to reach a “common language” independent of the protocol or serialisation format.
+The overall goal of the Vehicle Signal Specification (VSS) is to create a common understanding of vehicle signals in order to reach a “common language” independent of the protocol or serialisation format.
 
 Please find the official documentation at: [Vehicle Signal Specification](https://covesa.github.io/vehicle_signal_specification/)
 
@@ -12,9 +12,13 @@ Please find the official documentation at: [Vehicle Signal Specification](https:
 
 ### Using VSS
 To use a specific version of VSS in your toolchain, head over to our [releases page](https://github.com/COVESA/vehicle_signal_specification/releases/).
+The latest official release can be found [here](https://github.com/COVESA/vehicle_signal_specification/releases/latest).
 
+Work towards the next version is continuously ongoing in the [master branch](https://github.com/COVESA/vehicle_signal_specification/tree/master).
+To work with the specification directly, you need to clone this repository.
 
-[Latest release](https://github.com/COVESA/vehicle_signal_specification/releases/latest)
+For more information on how to set up the development environment and to be able to transform source *.vspec files to
+other formats see our [build guideline document](BUILD.md) and documentation in [VSS-tools](https://github.com/COVESA/vss-tools/blob/master/README.md).
 
 ### Discuss all things VSS, "meet" the community
 
@@ -22,26 +26,9 @@ The community has regular calls to discuss topics around VSS.
 This includes specific tickets in this repository as well as the broader direction in which VSS is evolving.
 You can find current call coordinates and dates in [our wiki](https://github.com/COVESA/vehicle_signal_specification/wiki/Weekly-meeting#meeting).
 
-
 ### Contribute to VSS
 
-Work towards the next version is continuously ongoing in the [master branch](https://github.com/COVESA/vehicle_signal_specification/tree/master)
-
-To work with the specification directly, you need to clone this repository.
-
-This repository uses git submodules.  Please make sure you clone recursively,
-
-```
-git clone --recurse-submodules https://github.com/COVESA/vehicle_signal_specification
-```
-
-
-Alternatively, just init and update the submodules after the initial cloning:
-
-```
-git clone https://github.com/COVESA/vehicle_signal_specification
-git submodule update --init
-```
+For detailed information see our [contribution guide](CONTRIBUTING.md)!
 
 ### VSS version and release handling
 


### PR DESCRIPTION
Current status:

- In this repo we do not mention how to use the Makefile
- We also do not mention what dependencies that are needed to be able to run `make`

(Most information is available in vss-tools repo, but not visible here)