### PR TITLE
Split fuel/charge port location signal

### DIFF
--- a/spec/Body/Body.vspec
+++ b/spec/Body/Body.vspec
@@ -17,6 +17,8 @@ BodyType:
   description: Body type code as defined by ISO 3779.
 
 RefuelPosition:
+  deprecation: v4.1 replaced with Vehicle.Powertrain.TractionBattery.Charging.ChargePortPosition
+               and Vehicle.Powertrain.FuelSystem.RefuelPortPosition
   datatype: string
   type: attribute
   allowed: ['FRONT_LEFT', 'FRONT_RIGHT', 'MIDDLE_LEFT', 'MIDDLE_RIGHT', 'REAR_LEFT', 'REAR_RIGHT']

--- a/spec/Powertrain/FuelSystem.vspec
+++ b/spec/Powertrain/FuelSystem.vspec
@@ -101,3 +101,18 @@ IsFuelLevelLow:
   datatype: boolean
   type: sensor
   description: Indicates that the fuel level is low (e.g. <50km range).
+
+RefuelPortPosition:
+  datatype: string[]
+  type: attribute
+  allowed: ['FRONT_LEFT', 'FRONT_MIDDLE', 'FRONT_RIGHT',
+            'REAR_LEFT', 'REAR_MIDDLE', 'REAR_RIGHT',
+            'LEFT_FRONT', 'LEFT_MIDDLE', 'LEFT_REAR',
+            'RIGHT_FRONT', 'RIGHT_MIDDLE', 'RIGHT_REAR']
+  description: Position of refuel port(s).
+               First part indicates side of vehicle, second part relative position on that side.
+
+IsFuelPortFlapOpen:
+  datatype: boolean
+  type: actuator
+  description: Status of the fuel port flap(s). True if at least one is open.

--- a/spec/Powertrain/TractionBattery.vspec
+++ b/spec/Powertrain/TractionBattery.vspec
@@ -274,10 +274,18 @@ Charging.MaximumChargingCurrent.Phase3:
   description: Maximum AC charging current (rms) at inlet for Phase 3 that can be accepted by the system.
 
 Charging.ChargePortFlap:
+  deprecation: V4.1 - Replaced with Charging.IsChargePortFlapOpen
   datatype: string
   type: actuator
   allowed: ['OPEN', 'CLOSED']
-  description: Status of the charge port cover, can potentially be controlled manually.
+  description: Status of the charge port cover(s), can potentially be controlled manually.
+               OPEN if at least one is open.
+
+Charging.IsChargePortFlapOpen:
+  datatype: boolean
+  type: actuator
+  description: Status of the charge port flap(s), can potentially be controlled manually.
+               True if at least one is open.
 
 Charging.IsChargingCableConnected:
   datatype: boolean
@@ -291,6 +299,7 @@ Charging.IsChargingCableLocked:
   comment: Locking of charging cable can be used to prevent unintentional removing during charging.
 
 Charging.ChargePlugType:
+  deprecation: V4.1 renamed to Charging.ChargePortType
   datatype: string[]
   type: attribute
   allowed: [
@@ -307,9 +316,12 @@ Charging.ChargePlugType:
     'GBT_DC',
     'OTHER'
     ]
-  description: Type of charge plug (charging inlet) available on the vehicle.
+  description: Type of charge plugs (charging inlet) available on the vehicle.
+               A charge plug type may occur multiple times in the list if there are multiple instances of that charge
+               plug type.
                IEC types refer to IEC 62196,  GBT refers to  GB/T 20234.
   comment:     A vehicle may have multiple charging inlets.
+               The signal Charging.ChargePlugPosition can be used to indicate position of the charge plug.
                IEC_TYPE_1_AC refers to Type 1 as defined in IEC 62196-2. Also known as Yazaki or J1772 connector.
                IEC_TYPE_2_AC refers to Type 2 as defined in IEC 62196-2. Also known as Mennekes connector.
                IEC_TYPE_3_AC refers to Type 3 as defined in IEC 62196-2. Also known as Scame connector.
@@ -322,6 +334,57 @@ Charging.ChargePlugType:
                GBT_DC refers to connector specified in GB/T 20234.3. Also specified as BB Configuration in IEC 62196-3.
                OTHER shall be used if the vehicle has a charging connector, but not one of the connectors listed above.
                For additional information see https://en.wikipedia.org/wiki/IEC_62196.
+
+Charging.ChargePortType:
+  datatype: string[]
+  type: attribute
+  allowed: [
+    'IEC_TYPE_1_AC',
+    'IEC_TYPE_2_AC',
+    'IEC_TYPE_3_AC',
+    'IEC_TYPE_4_DC',
+    'IEC_TYPE_1_CCS_DC',
+    'IEC_TYPE_2_CCS_DC',
+    'TESLA_ROADSTER',
+    'TESLA_HPWC',
+    'TESLA_SUPERCHARGER',
+    'GBT_AC',
+    'GBT_DC',
+    'OTHER'
+    ]
+  description: Type of charge ports (charging inlet) available on the vehicle.
+               A charge port type may occur multiple times in the list if there are multiple instances of that charge
+               port type.
+               IEC types refer to IEC 62196,  GBT refers to  GB/T 20234.
+  comment:     A vehicle may have multiple charging ports.
+               The signal Charging.ChargePortPosition can be used to indicate position of the charge port.
+               IEC_TYPE_1_AC refers to Type 1 as defined in IEC 62196-2. Also known as Yazaki or J1772 connector.
+               IEC_TYPE_2_AC refers to Type 2 as defined in IEC 62196-2. Also known as Mennekes connector.
+               IEC_TYPE_3_AC refers to Type 3 as defined in IEC 62196-2. Also known as Scame connector.
+               IEC_TYPE_4_DC refers to AA configuration as defined in IEC 62196-3. Also known as Type 4 or CHAdeMO connector.
+               IEC_TYPE_1_CCS_DC refers to EE Configuration as defined in IEC 62196-3. Also known as CCS1 or Combo1 connector.
+               IEC_TYPE_2_CCS_DC refers to FF Configuration as defined in IEC 62196-3. Also known as CCS2 or Combo2 connector.
+               TESLA_ROADSTER, TESLA_HPWC (High Power Wall Connector) and TESLA_SUPERCHARGER refer to non-standardized charging
+               ports/methods used by Tesla.
+               GBT_AC refers to connector specified in GB/T 20234.2.
+               GBT_DC refers to connector specified in GB/T 20234.3. Also specified as BB Configuration in IEC 62196-3.
+               OTHER shall be used for charging ports not included in the list above.
+               For additional information see https://en.wikipedia.org/wiki/IEC_62196.
+
+Charging.ChargePortPosition:
+  datatype: string[]
+  type: attribute
+  allowed: ['FRONT_LEFT', 'FRONT_MIDDLE', 'FRONT_RIGHT',
+            'REAR_LEFT', 'REAR_MIDDLE', 'REAR_RIGHT',
+            'LEFT_FRONT', 'LEFT_MIDDLE', 'LEFT_REAR',
+            'RIGHT_FRONT', 'RIGHT_MIDDLE', 'RIGHT_REAR']
+  description: Location of the charge port(s).
+               First part indicates side of vehicle, second part relative position on that side.
+               If supported, the list in this attribute shall have the same length as Charging.ChargePortType,
+               and use same the relative order.
+  comment: Example - If this signal is [LEFT_FRONT, RIGHT_FRONT] and Charging.ChargePortType is
+           [IEC_TYPE_2_AC, GBT_AC] that means that there is Mennekes port on the left side of the vehicle near
+           the front, and a GB/T AC port on the right side, near the front.
 
 Charging.Mode:
   datatype: string


### PR DESCRIPTION
This tries to refactor VSS to be more aligned with Android VHAL.

In VHAL three signals exist:

- INFO_FUEL_DOOR_LOCATION
- INFO_CHARGE_PORT_LOCATION
- FUEL_DOOR_OPEN

In VSS so far we had a joint signal for fuel door and charge port, but that does not work well for hybrids. We also lacked some positions like front/rear, so I added them. I kept the "middle" positions, but do not really know how useful they are.