### PR TITLE
Updating actions/checkout

### DIFF
--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
 


### PR DESCRIPTION
To get rid of Node.js 12 dependency

(Note: DCO check still use Node.js 12)