### PR TITLE
Change description of Lights.Running

### DIFF
--- a/spec/Body/Body.vspec
+++ b/spec/Body/Body.vspec
@@ -208,7 +208,7 @@ Lights.Beam:
 
 Lights.Running:
   type: branch
-  description: Running lights.
+  description: Daytime running lights (DRL).
 #include StaticLights.vspec Lights.Running
 
 Lights.Backup:


### PR DESCRIPTION
In e.g. DIN ISO 7000:2008-12 the term
"Daytime running lights" (Tagfahrlicht) is used as a description for symbol 2611.
Including the names often used including the abbreviation DLR makes it easier to search for the signal.

_(This is based on the assumption that Lights.Running refers to DRL)_