### PR TITLE
Add additional mirror signals

### DIFF
--- a/spec/Body/ExteriorMirrors.vspec
+++ b/spec/Body/ExteriorMirrors.vspec
@@ -30,3 +30,13 @@ IsHeatingOn:
   datatype: boolean
   type: actuator
   description: Mirror Heater on or off. True = Heater On. False = Heater Off.
+
+IsLocked:
+  datatype: boolean
+  type: actuator
+  description: Is mirror movement locked? True = Locked, mirror will not react to Tilt/Pan change. False = Unlocked.
+
+IsFolded:
+  datatype: boolean
+  type: actuator
+  description: Is mirror folded? True = Fully or partially folded. False = Fully unfolded.


### PR DESCRIPTION
Inspired by the [Android signals](https://android.googlesource.com/platform/hardware/interfaces/+/master/automotive/vehicle/2.0/types.hal) MIRROR_LOCK and MIRROR_FOLD.

**Lock Signal**

This signal might reflect the quite common design vehicle where you have common up/down/left/right buttons and a separate switch to decide if it shall affect left/right/none mirror. I.e. in "none" both left and right are locked

**Fold signal**

It can be discussed if we rather would need a percent-signal, where 100% either means fully folded or fully unfolded. Might be useful if you want to monitor progress or control speed.