### PR TITLE
Change datatype for HVAC temeprature 

### DIFF
--- a/spec/Cabin/SingleHVACStation.vspec
+++ b/spec/Cabin/SingleHVACStation.vspec
@@ -19,7 +19,7 @@ FanSpeed:
   description: Fan Speed, 0 = off. 100 = max
 
 Temperature:
-  datatype: int8
+  datatype: float
   type: actuator
   unit: celsius
   description: Temperature


### PR DESCRIPTION
It was defined as int, most cars are drive have 0.5°C steps to set temperature, which can not be mapped to the current VSS model.

Changing this to float in the model fixed it, and then it is up to an app/user to represent this with a lower granularity if requried.