### PR TITLE
Change copyright headers

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max_line_length = 120

--- a/.github/actions/verify-headers/action.yml
+++ b/.github/actions/verify-headers/action.yml
@@ -1,0 +1,17 @@
+name: verify-headers
+description: Verify that files affected by a PR include expected header
+
+branding:
+  icon: zap
+  color: gray-dark
+
+inputs:
+  files:
+    description: >
+      A comma-separated list of all files to check.
+    default: ''
+runs:
+  using: "composite"
+  steps:
+    - run: $GITHUB_ACTION_PATH/verify-headers.py
+      shell: bash

--- a/.github/actions/verify-headers/verify-headers.py
+++ b/.github/actions/verify-headers/verify-headers.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python3
+# Copyright (c) 2023 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
+import os
+
+
+def string_exists(file_path, search_string) -> bool:
+    with open(file_path, 'r') as file:
+        content = file.read()
+        if search_string in content:
+            return True
+    return False
+
+
+if __name__ == '__main__':
+
+    files = os.getenv('files')
+    files = files.split(',')
+    for file in files:
+        file = os.path.abspath(file)
+        if os.path.isfile(file):
+            ext = os.path.splitext(file)[1]
+            if ext in [".vspec", ".py"]:
+                if not string_exists(file, "Contributors to COVESA"):
+                    print(f"No contribution statement found in {file}")
+                    raise Exception("Check the output, some files have not the right contribution statement!")
+                if not string_exists(file, "SPDX-License-Identifier: MPL-2.0"):
+                    print(f"Incorrect license statement found in {file}")
+                    raise Exception("Check the output, some files have not the right SPDX statement!")
+
+                print(f"Check succeeded for {file}")
+    raise SystemExit(0)

--- a/.github/workflows/check-header.yml
+++ b/.github/workflows/check-header.yml
@@ -1,0 +1,28 @@
+name: check-header
+
+on:
+  pull_request
+
+concurrency:
+      group: ${{ github.ref }}-${{ github.workflow }}
+      cancel-in-progress: true
+
+jobs:
+  check-headers:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        # required to grab the history of the PR
+        fetch-depth: 0
+
+    - name: Get changed files
+      run: |
+        echo "files=$(git diff --name-only ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | tr '\n' ',')" >> $GITHUB_ENV
+
+    - uses: ./.github/actions/verify-headers
+      with:
+        files: "${{ env.files }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,15 +63,25 @@ By supplying this sign-off line, you indicate your acceptance of the COVESA Cert
 
 If using git command line you can add a sign-off by using the `-s` argument when creating a commit.
 
-Each file shall have copyright statement of this form, inspired by the [Eclipse generic copyright header](https://www.eclipse.org/projects/handbook/#ip-copyright-headers)
+For certain files it is requested that a copyright and license statement is added as file header.
+This currently applies to the following file types:
+
+* VSS source files (`*.vspec`)
+* Python files (vss-tools, `*.py`)
+
+Those files shall have copyright statement of this form, inspired by the [Eclipse generic copyright header](https://www.eclipse.org/projects/handbook/#ip-copyright-headers).
+Copyright/License-statement may also be added to other files if considered relevant.
 
 ```
-# Copyright (c) XXXX Contributors to COVESA
+# Copyright (c) {year} Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
-```
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
 
+```
 Where XXXX is the year the file was originally created, no need to update or append new years or a range of years later.
 
 ### VSS Signals shall be generic

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,17 @@ By supplying this sign-off line, you indicate your acceptance of the COVESA Cert
 
 If using git command line you can add a sign-off by using the `-s` argument when creating a commit.
 
+Each file shall have copyright statement of this form, inspired by the [Eclipse generic copyright header](https://www.eclipse.org/projects/handbook/#ip-copyright-headers)
+
+```
+# Copyright (c) XXXX Contributors to COVESA
+#
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
+```
+
+Where XXXX is the year the file was originally created, no need to update or append new years or a range of years later.
+
 ### VSS Signals shall be generic
 
 Signals added to standard VSS shall be generic, i.e. it shall be possible that other manufacturers can reuse the signal.

--- a/overlays/extensions/dual_wiper_systems.vspec
+++ b/overlays/extensions/dual_wiper_systems.vspec
@@ -1,7 +1,10 @@
-## Copyright (c) 2022 Contributors to COVESA
+# Copyright (c) 2022 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
 
 # Overlay to extend wiper system to support multiple instances
 # Dependencies to other overlays: None

--- a/overlays/extensions/dual_wiper_systems.vspec
+++ b/overlays/extensions/dual_wiper_systems.vspec
@@ -1,6 +1,8 @@
+## Copyright (c) 2022 Contributors to COVESA
 #
-# (C) 2022 Robert Bosch GmbH
-#
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
+
 # Overlay to extend wiper system to support multiple instances
 # Dependencies to other overlays: None
 # Known conflicts with other overlays: None

--- a/overlays/profiles/motorbike.vspec
+++ b/overlays/profiles/motorbike.vspec
@@ -1,7 +1,10 @@
-## Copyright (c) 2022 Contributors to COVESA
+# Copyright (c) 2022 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
 
 # This file contains adoptions to the main spec concering motorbikes.
 # It mainly addresses istantiation issues (e.g. wheels) and

--- a/overlays/profiles/motorbike.vspec
+++ b/overlays/profiles/motorbike.vspec
@@ -1,11 +1,8 @@
-#
-# (C) 2022, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
-# (C) 2022 Robert Bosch GmbH
+## Copyright (c) 2022 Contributors to COVESA
 #
 # All files and artifacts in this repository are licensed under the
 # provisions of the license provided by the LICENSE file in this repository.
-#
-#
+
 # This file contains adoptions to the main spec concering motorbikes.
 # It mainly addresses istantiation issues (e.g. wheels) and
 # additional signals, which are motorbike specific (e.g. handlebars).

--- a/spec/ADAS/ADAS.vspec
+++ b/spec/ADAS/ADAS.vspec
@@ -1,11 +1,7 @@
-#
-# (C) 2022 Robert Bosch GmbH
-# (C) 2018 Volvo Cars
-# (C) 2016 Jaguar Land Rover
+## Copyright (c) 2016 Contributors to COVESA
 #
 # All files and artifacts in this repository are licensed under the
 # provisions of the license provided by the LICENSE file in this repository.
-#
 
 #
 # All Advanced Driver Assist System signals

--- a/spec/ADAS/ADAS.vspec
+++ b/spec/ADAS/ADAS.vspec
@@ -1,7 +1,10 @@
-## Copyright (c) 2016 Contributors to COVESA
+# Copyright (c) 2016 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
 
 #
 # All Advanced Driver Assist System signals

--- a/spec/Body/Body.vspec
+++ b/spec/Body/Body.vspec
@@ -1,7 +1,10 @@
-## Copyright (c) 2016 Contributors to COVESA
+# Copyright (c) 2016 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
 
 #
 # All body signals and attributes.

--- a/spec/Body/Body.vspec
+++ b/spec/Body/Body.vspec
@@ -1,11 +1,7 @@
-#
-# (C) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
-# (C) 2018 Volvo Cars
-# (C) 2016 Jaguar Land Rover
+## Copyright (c) 2016 Contributors to COVESA
 #
 # All files and artifacts in this repository are licensed under the
 # provisions of the license provided by the LICENSE file in this repository.
-#
 
 #
 # All body signals and attributes.

--- a/spec/Body/BrakeLights.vspec
+++ b/spec/Body/BrakeLights.vspec
@@ -1,7 +1,10 @@
-## Copyright (c) 2022 Contributors to COVESA
+# Copyright (c) 2022 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
 
 IsActive:
   datatype: string

--- a/spec/Body/BrakeLights.vspec
+++ b/spec/Body/BrakeLights.vspec
@@ -1,6 +1,7 @@
+## Copyright (c) 2022 Contributors to COVESA
 #
-# (C) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - All rights reserved.
-#
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 
 IsActive:
   datatype: string

--- a/spec/Body/ExteriorMirrors.vspec
+++ b/spec/Body/ExteriorMirrors.vspec
@@ -1,7 +1,10 @@
-## Copyright (c) 2016 Contributors to COVESA
+# Copyright (c) 2016 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
 
 #
 # All exterior mirrors

--- a/spec/Body/ExteriorMirrors.vspec
+++ b/spec/Body/ExteriorMirrors.vspec
@@ -1,10 +1,7 @@
-#
-# (C) 2018 Volvo Cars
-# (C) 2016 Jaguar Land Rover
+## Copyright (c) 2016 Contributors to COVESA
 #
 # All files and artifacts in this repository are licensed under the
 # provisions of the license provided by the LICENSE file in this repository.
-#
 
 #
 # All exterior mirrors

--- a/spec/Body/SignalingLights.vspec
+++ b/spec/Body/SignalingLights.vspec
@@ -1,7 +1,10 @@
-## Copyright (c) 2022 Contributors to COVESA
+# Copyright (c) 2022 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
 
 IsSignaling:
   datatype: boolean

--- a/spec/Body/SignalingLights.vspec
+++ b/spec/Body/SignalingLights.vspec
@@ -1,6 +1,7 @@
+## Copyright (c) 2022 Contributors to COVESA
 #
-# (C) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - All rights reserved.
-#
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 
 IsSignaling:
   datatype: boolean

--- a/spec/Body/StaticLights.vspec
+++ b/spec/Body/StaticLights.vspec
@@ -1,6 +1,7 @@
+## Copyright (c) 2022 Contributors to COVESA
 #
-# (C) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - All rights reserved.
-#
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 
 IsOn:
   datatype: boolean

--- a/spec/Body/StaticLights.vspec
+++ b/spec/Body/StaticLights.vspec
@@ -1,7 +1,10 @@
-## Copyright (c) 2022 Contributors to COVESA
+# Copyright (c) 2022 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
 
 IsOn:
   datatype: boolean

--- a/spec/Body/WiperSystem.vspec
+++ b/spec/Body/WiperSystem.vspec
@@ -1,7 +1,10 @@
-## Copyright (c) 2022 Contributors to COVESA
+# Copyright (c) 2022 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
 
 # This file describes signals for a wiper system interface, allowing movement for one or more wipers
 # to be controlled in great detail.

--- a/spec/Body/WiperSystem.vspec
+++ b/spec/Body/WiperSystem.vspec
@@ -1,9 +1,8 @@
-#
-# (C) 2022 Robert Bosch GmbH
+## Copyright (c) 2022 Contributors to COVESA
 #
 # All files and artifacts in this repository are licensed under the
 # provisions of the license provided by the LICENSE file in this repository.
-#
+
 # This file describes signals for a wiper system interface, allowing movement for one or more wipers
 # to be controlled in great detail.
 #

--- a/spec/Cabin/Cabin.vspec
+++ b/spec/Cabin/Cabin.vspec
@@ -1,11 +1,7 @@
-#
-# (C) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
-# (C) 2018 Volvo Cars
-# (C) 2016 Jaguar Land Rover
+## Copyright (c) 2016 Contributors to COVESA
 #
 # All files and artifacts in this repository are licensed under the
 # provisions of the license provided by the LICENSE file in this repository.
-#
 
 #
 # All in-cabin originated signals and attributes

--- a/spec/Cabin/Cabin.vspec
+++ b/spec/Cabin/Cabin.vspec
@@ -1,7 +1,10 @@
-## Copyright (c) 2016 Contributors to COVESA
+# Copyright (c) 2016 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
 
 #
 # All in-cabin originated signals and attributes

--- a/spec/Cabin/HVAC.vspec
+++ b/spec/Cabin/HVAC.vspec
@@ -1,7 +1,10 @@
-## Copyright (c) 2016 Contributors to COVESA
+# Copyright (c) 2016 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
 
 #
 # All HVAC-originated signals

--- a/spec/Cabin/HVAC.vspec
+++ b/spec/Cabin/HVAC.vspec
@@ -1,11 +1,7 @@
-#
-# (C) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
-# (C) 2018 Volvo Cars
-# (C) 2016 Jaguar Land Rover
+## Copyright (c) 2016 Contributors to COVESA
 #
 # All files and artifacts in this repository are licensed under the
 # provisions of the license provided by the LICENSE file in this repository.
-#
 
 #
 # All HVAC-originated signals

--- a/spec/Cabin/Infotainment.vspec
+++ b/spec/Cabin/Infotainment.vspec
@@ -1,10 +1,7 @@
-#
-# (C) 2018 Volvo Cars
-# (C) 2016 Jaguar Land Rover
+## Copyright (c) 2016 Contributors to COVESA
 #
 # All files and artifacts in this repository are licensed under the
 # provisions of the license provided by the LICENSE file in this repository.
-#
 
 #
 # In-Vehicle Infotainment Signals

--- a/spec/Cabin/Infotainment.vspec
+++ b/spec/Cabin/Infotainment.vspec
@@ -1,7 +1,10 @@
-## Copyright (c) 2016 Contributors to COVESA
+# Copyright (c) 2016 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
 
 #
 # In-Vehicle Infotainment Signals

--- a/spec/Cabin/InteriorLights.vspec
+++ b/spec/Cabin/InteriorLights.vspec
@@ -1,11 +1,7 @@
-#
-# (C) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
-# (C) 2018 Volvo Cars
-# (C) 2016 Jaguar Land Rover
+## Copyright (c) 2016 Contributors to COVESA
 #
 # All files and artifacts in this repository are licensed under the
 # provisions of the license provided by the LICENSE file in this repository.
-#
 
 #
 # All interior lights and sensors

--- a/spec/Cabin/InteriorLights.vspec
+++ b/spec/Cabin/InteriorLights.vspec
@@ -1,7 +1,10 @@
-## Copyright (c) 2016 Contributors to COVESA
+# Copyright (c) 2016 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
 
 #
 # All interior lights and sensors

--- a/spec/Cabin/Occupant.vspec
+++ b/spec/Cabin/Occupant.vspec
@@ -1,7 +1,11 @@
-## Copyright (c) 2020 Contributors to COVESA
+# Copyright (c) 2020 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
 #
 # Occupant data
 #

--- a/spec/Cabin/Occupant.vspec
+++ b/spec/Cabin/Occupant.vspec
@@ -1,9 +1,7 @@
-#
-# (C) 2020 Robert Bosch GmbH
+## Copyright (c) 2020 Contributors to COVESA
 #
 # All files and artifacts in this repository are licensed under the
 # provisions of the license provided by the LICENSE file in this repository.
-#
 #
 # Occupant data
 #

--- a/spec/Cabin/SingleConfigurableLight.vspec
+++ b/spec/Cabin/SingleConfigurableLight.vspec
@@ -1,9 +1,7 @@
-#
-# (C) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+## Copyright (c) 2023 Contributors to COVESA
 #
 # All files and artifacts in this repository are licensed under the
 # provisions of the license provided by the LICENSE file in this repository.
-#
 
 #
 # Generic specification for a light whose color and brightness can be configured.

--- a/spec/Cabin/SingleConfigurableLight.vspec
+++ b/spec/Cabin/SingleConfigurableLight.vspec
@@ -1,7 +1,11 @@
-## Copyright (c) 2023 Contributors to COVESA
+# Copyright (c) 2023 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
 
 #
 # Generic specification for a light whose color and brightness can be configured.

--- a/spec/Cabin/SingleDoor.vspec
+++ b/spec/Cabin/SingleDoor.vspec
@@ -1,7 +1,11 @@
-## Copyright (c) 2016 Contributors to COVESA
+# Copyright (c) 2023 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
 
 #
 # Definition of a single door. Start position for Door is Closed.

--- a/spec/Cabin/SingleDoor.vspec
+++ b/spec/Cabin/SingleDoor.vspec
@@ -1,10 +1,7 @@
-#
-# (C) 2018 Volvo Cars
-# (C) 2016 Jaguar Land Rover
+## Copyright (c) 2016 Contributors to COVESA
 #
 # All files and artifacts in this repository are licensed under the
 # provisions of the license provided by the LICENSE file in this repository.
-#
 
 #
 # Definition of a single door. Start position for Door is Closed.

--- a/spec/Cabin/SingleHVACStation.vspec
+++ b/spec/Cabin/SingleHVACStation.vspec
@@ -1,10 +1,7 @@
-#
-# (C) 2018 Volvo Cars
-# (C) 2016 Jaguar Land Rover
+## Copyright (c) 2016 Contributors to COVESA
 #
 # All files and artifacts in this repository are licensed under the
 # provisions of the license provided by the LICENSE file in this repository.
-#
 
 #
 # A single HVAC station in the vehicle.

--- a/spec/Cabin/SingleHVACStation.vspec
+++ b/spec/Cabin/SingleHVACStation.vspec
@@ -1,7 +1,10 @@
-## Copyright (c) 2016 Contributors to COVESA
+# Copyright (c) 2016 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
 
 #
 # A single HVAC station in the vehicle.

--- a/spec/Cabin/SingleSeat.vspec
+++ b/spec/Cabin/SingleSeat.vspec
@@ -1,11 +1,7 @@
-#
-# (C) 2022 Robert Bosch GmbH
-# (C) 2018 Volvo Cars
-# (C) 2016 Jaguar Land Rover
+## Copyright (c) 2016 Contributors to COVESA
 #
 # All files and artifacts in this repository are licensed under the
 # provisions of the license provided by the LICENSE file in this repository.
-#
 
 #
 # Seat signals

--- a/spec/Cabin/SingleSeat.vspec
+++ b/spec/Cabin/SingleSeat.vspec
@@ -1,7 +1,10 @@
-## Copyright (c) 2016 Contributors to COVESA
+# Copyright (c) 2016 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
 
 #
 # Seat signals

--- a/spec/Chassis/Chassis.vspec
+++ b/spec/Chassis/Chassis.vspec
@@ -1,10 +1,7 @@
-#
-# (C) 2018 Volvo Cars
-# (C) 2016 Jaguar Land Rover
+## Copyright (c) 2016 Contributors to COVESA
 #
 # All files and artifacts in this repository are licensed under the
 # provisions of the license provided by the LICENSE file in this repository.
-#
 
 #
 # Chassis signals and attributes

--- a/spec/Chassis/Chassis.vspec
+++ b/spec/Chassis/Chassis.vspec
@@ -1,7 +1,10 @@
-## Copyright (c) 2016 Contributors to COVESA
+# Copyright (c) 2016 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
 
 #
 # Chassis signals and attributes

--- a/spec/Chassis/Wheel.vspec
+++ b/spec/Chassis/Wheel.vspec
@@ -1,7 +1,10 @@
-## Copyright (c) 2016 Contributors to COVESA
+# Copyright (c) 2016 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
 
 #
 # Brake

--- a/spec/Chassis/Wheel.vspec
+++ b/spec/Chassis/Wheel.vspec
@@ -1,10 +1,7 @@
-#
-# (C) 2018 Volvo Cars
-# (C) 2016 Jaguar Land Rover
+## Copyright (c) 2016 Contributors to COVESA
 #
 # All files and artifacts in this repository are licensed under the
 # provisions of the license provided by the LICENSE file in this repository.
-#
 
 #
 # Brake

--- a/spec/Driver/Driver.vspec
+++ b/spec/Driver/Driver.vspec
@@ -1,7 +1,10 @@
-## Copyright (c) 2020 Contributors to COVESA
+# Copyright (c) 2020 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
 
 #
 # Driver data

--- a/spec/Driver/Driver.vspec
+++ b/spec/Driver/Driver.vspec
@@ -1,9 +1,8 @@
-#
-# (C) 2020 Robert Bosch GmbH
+## Copyright (c) 2020 Contributors to COVESA
 #
 # All files and artifacts in this repository are licensed under the
 # provisions of the license provided by the LICENSE file in this repository.
-#
+
 #
 # Driver data
 #

--- a/spec/Identifier/Identifier.vspec
+++ b/spec/Identifier/Identifier.vspec
@@ -1,7 +1,10 @@
-## Copyright (c) 2020 Contributors to COVESA
+# Copyright (c) 2020 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
 
 #
 # Identifier

--- a/spec/Identifier/Identifier.vspec
+++ b/spec/Identifier/Identifier.vspec
@@ -1,9 +1,8 @@
-#
-# (C) 2020 Robert Bosch GmbH
+## Copyright (c) 2020 Contributors to COVESA
 #
 # All files and artifacts in this repository are licensed under the
 # provisions of the license provided by the LICENSE file in this repository.
-#
+
 #
 # Identifier
 # Based on OAuth 2.0. Subject is the UserID inside the claim of the Issuer Domain.

--- a/spec/OBD/OBD.vspec
+++ b/spec/OBD/OBD.vspec
@@ -1,8 +1,10 @@
-## Copyright (c) 2016 Contributors to COVESA
+# Copyright (c) 2016 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
-
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
 
 #
 # On-Board Diagnostic (OBD) Signals

--- a/spec/OBD/OBD.vspec
+++ b/spec/OBD/OBD.vspec
@@ -1,12 +1,7 @@
-#
-# (C) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
-# (C) 2020 Robert Bosch GmbH
-# (C) 2018 Volvo Cars
-# (C) 2016 Jaguar Land Rover
+## Copyright (c) 2016 Contributors to COVESA
 #
 # All files and artifacts in this repository are licensed under the
 # provisions of the license provided by the LICENSE file in this repository.
-#
 
 
 #

--- a/spec/Powertrain/CombustionEngine.vspec
+++ b/spec/Powertrain/CombustionEngine.vspec
@@ -1,11 +1,7 @@
-#
-# (C) 2020 Robert Bosch GmbH
-# (C) 2018 Volvo Cars
-# (C) 2016 Jaguar Land Rover
+## Copyright (c) 2016 Contributors to COVESA
 #
 # All files and artifacts in this repository are licensed under the
 # provisions of the license provided by the LICENSE file in this repository.
-#
 
 #
 # ENGINE SPECIFICATION FILE

--- a/spec/Powertrain/CombustionEngine.vspec
+++ b/spec/Powertrain/CombustionEngine.vspec
@@ -1,7 +1,10 @@
-## Copyright (c) 2016 Contributors to COVESA
+# Copyright (c) 2016 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
 
 #
 # ENGINE SPECIFICATION FILE

--- a/spec/Powertrain/ElectricMotor.vspec
+++ b/spec/Powertrain/ElectricMotor.vspec
@@ -1,7 +1,10 @@
-## Copyright (c) 2016 Contributors to COVESA
+# Copyright (c) 2016 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
 
 #
 # EV Motor signals and attributes

--- a/spec/Powertrain/ElectricMotor.vspec
+++ b/spec/Powertrain/ElectricMotor.vspec
@@ -1,10 +1,7 @@
-#
-# (C) 2020 Robert Bosch GmbH
-# (C) 2016 Jaguar Land Rover
+## Copyright (c) 2016 Contributors to COVESA
 #
 # All files and artifacts in this repository are licensed under the
 # provisions of the license provided by the LICENSE file in this repository.
-#
 
 #
 # EV Motor signals and attributes

--- a/spec/Powertrain/FuelSystem.vspec
+++ b/spec/Powertrain/FuelSystem.vspec
@@ -1,10 +1,7 @@
-#
-# (C) 2018 Volvo Cars
-# (C) 2016 Jaguar Land Rover
+## Copyright (c) 2016 Contributors to COVESA
 #
 # All files and artifacts in this repository are licensed under the
 # provisions of the license provided by the LICENSE file in this repository.
-#
 
 #
 # Fuel system for ICE / hybrids

--- a/spec/Powertrain/FuelSystem.vspec
+++ b/spec/Powertrain/FuelSystem.vspec
@@ -1,7 +1,10 @@
-## Copyright (c) 2016 Contributors to COVESA
+# Copyright (c) 2016 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
 
 #
 # Fuel system for ICE / hybrids

--- a/spec/Powertrain/Powertrain.vspec
+++ b/spec/Powertrain/Powertrain.vspec
@@ -1,7 +1,7 @@
+## Copyright (c) 2016 Contributors to COVESA
+#
 # All files and artifacts in this repository are licensed under the
 # provisions of the license provided by the LICENSE file in this repository.
-#
-
 
 AccumulatedBrakingEnergy:
   datatype: float

--- a/spec/Powertrain/Powertrain.vspec
+++ b/spec/Powertrain/Powertrain.vspec
@@ -1,7 +1,10 @@
-## Copyright (c) 2016 Contributors to COVESA
+# Copyright (c) 2016 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
 
 AccumulatedBrakingEnergy:
   datatype: float

--- a/spec/Powertrain/TractionBattery.vspec
+++ b/spec/Powertrain/TractionBattery.vspec
@@ -1,11 +1,7 @@
-#
-# (C) 2020 Robert Bosch GmbH
-# (C) 2018 Volvo Cars
-# (C) 2016 Jaguar Land Rover
+## Copyright (c) 2016 Contributors to COVESA
 #
 # All files and artifacts in this repository are licensed under the
 # provisions of the license provided by the LICENSE file in this repository.
-#
 
 #
 # Signals and attributes related to the traction battery in vehicles with electrical powertrain.

--- a/spec/Powertrain/TractionBattery.vspec
+++ b/spec/Powertrain/TractionBattery.vspec
@@ -1,7 +1,10 @@
-## Copyright (c) 2016 Contributors to COVESA
+# Copyright (c) 2016 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
 
 #
 # Signals and attributes related to the traction battery in vehicles with electrical powertrain.

--- a/spec/Powertrain/Transmission.vspec
+++ b/spec/Powertrain/Transmission.vspec
@@ -1,7 +1,10 @@
-## Copyright (c) 2016 Contributors to COVESA
+# Copyright (c) 2016 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
 
 #
 # TRANSMISSION SPECIFICATION FILE

--- a/spec/Powertrain/Transmission.vspec
+++ b/spec/Powertrain/Transmission.vspec
@@ -1,11 +1,7 @@
-#
-# (C) 2021 Robert Bosch GmbH
-# (C) 2018 Volvo Cars
-# (C) 2016 Jaguar Land Rover
+## Copyright (c) 2016 Contributors to COVESA
 #
 # All files and artifacts in this repository are licensed under the
 # provisions of the license provided by the LICENSE file in this repository.
-#
 
 #
 # TRANSMISSION SPECIFICATION FILE

--- a/spec/Vehicle/Battery.vspec
+++ b/spec/Vehicle/Battery.vspec
@@ -1,8 +1,7 @@
+## Copyright (c) 2022 Contributors to COVESA
 #
-# (C) 2022 Robert Bosch GmbH
 # All files and artifacts in this repository are licensed under the
 # provisions of the license provided by the LICENSE file in this repository.
-#
 
 #
 # Signals and attributes related to the low voltage battery in Vehicles

--- a/spec/Vehicle/Battery.vspec
+++ b/spec/Vehicle/Battery.vspec
@@ -1,7 +1,10 @@
-## Copyright (c) 2022 Contributors to COVESA
+# Copyright (c) 2022 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
 
 #
 # Signals and attributes related to the low voltage battery in Vehicles

--- a/spec/Vehicle/Connectivity.vspec
+++ b/spec/Vehicle/Connectivity.vspec
@@ -1,7 +1,11 @@
-## Copyright (c) 2022 Contributors to COVESA
+# Copyright (c) 2022 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
 #
 # Connectivity data
 #

--- a/spec/Vehicle/Connectivity.vspec
+++ b/spec/Vehicle/Connectivity.vspec
@@ -1,9 +1,7 @@
-#
-# (C) 2022 Robert Bosch GmbH
+## Copyright (c) 2022 Contributors to COVESA
 #
 # All files and artifacts in this repository are licensed under the
 # provisions of the license provided by the LICENSE file in this repository.
-#
 #
 # Connectivity data
 #

--- a/spec/Vehicle/Exterior.vspec
+++ b/spec/Vehicle/Exterior.vspec
@@ -1,7 +1,10 @@
-## Copyright (c) 2022 Contributors to COVESA
+# Copyright (c) 2022 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
 
 AirTemperature:
   datatype: float

--- a/spec/Vehicle/Exterior.vspec
+++ b/spec/Vehicle/Exterior.vspec
@@ -1,10 +1,7 @@
-#
-# (C) 2022 Robert Bosch GmbH
+## Copyright (c) 2022 Contributors to COVESA
 #
 # All files and artifacts in this repository are licensed under the
 # provisions of the license provided by the LICENSE file in this repository.
-#
-#
 
 AirTemperature:
   datatype: float

--- a/spec/Vehicle/Service.vspec
+++ b/spec/Vehicle/Service.vspec
@@ -1,7 +1,10 @@
-## Copyright (c) 2021 Contributors to COVESA
+# Copyright (c) 2021 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
 
 #
 # Service data

--- a/spec/Vehicle/Service.vspec
+++ b/spec/Vehicle/Service.vspec
@@ -1,9 +1,8 @@
-#
-# (C) 2021 Robert Bosch GmbH
+## Copyright (c) 2021 Contributors to COVESA
 #
 # All files and artifacts in this repository are licensed under the
 # provisions of the license provided by the LICENSE file in this repository.
-#
+
 #
 # Service data
 #

--- a/spec/Vehicle/Vehicle.vspec
+++ b/spec/Vehicle/Vehicle.vspec
@@ -1,12 +1,7 @@
-#
-# (C) 2022 Robert Bosch GmbH
-# (C) 2018 Volvo Cars
-# (C) 2016 Jaguar Land Rover
+## Copyright (c) 2016 Contributors to COVESA
 #
 # All files and artifacts in this repository are licensed under the
 # provisions of the license provided by the LICENSE file in this repository.
-#
-
 
 #
 # Highlevel vehicle signals and attributes.

--- a/spec/Vehicle/Vehicle.vspec
+++ b/spec/Vehicle/Vehicle.vspec
@@ -1,7 +1,10 @@
-## Copyright (c) 2016 Contributors to COVESA
+# Copyright (c) 2016 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
 
 #
 # Highlevel vehicle signals and attributes.

--- a/spec/VehicleSignalSpecification.vspec
+++ b/spec/VehicleSignalSpecification.vspec
@@ -1,7 +1,10 @@
 # Copyright (c) 2016 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
 
 #
 # Root Vehicle Signal Specification file

--- a/spec/VehicleSignalSpecification.vspec
+++ b/spec/VehicleSignalSpecification.vspec
@@ -1,11 +1,7 @@
-#
-# (C) 2020 Robert Bosch GmbH
-# (C) 2018 Volvo Cars
-# (C) 2016 Jaguar Land Rover
+# Copyright (c) 2016 Contributors to COVESA
 #
 # All files and artifacts in this repository are licensed under the
 # provisions of the license provided by the LICENSE file in this repository.
-#
 
 #
 # Root Vehicle Signal Specification file

--- a/spec/include/ItemHeatingCooling.vspec
+++ b/spec/include/ItemHeatingCooling.vspec
@@ -1,8 +1,10 @@
+# Copyright (c) 2023 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
 #
-
+# SPDX-License-Identifier: MPL-2.0
 
 HeatingCooling:
   datatype: int8

--- a/spec/include/LockableMovableItem.vspec
+++ b/spec/include/LockableMovableItem.vspec
@@ -1,11 +1,10 @@
+# Copyright (c) 2016 Contributors to COVESA
 #
-# (C) 2023 Robert Bosch GmbH
-# (C) 2018 Volvo Cars
-# (C) 2016 Jaguar Land Rover
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
-#
+# SPDX-License-Identifier: MPL-2.0
 
 #
 # Add-on to MovableItems that also are lockable

--- a/spec/include/MovableItem.vspec
+++ b/spec/include/MovableItem.vspec
@@ -1,10 +1,10 @@
+# Copyright (c) 2016 Contributors to COVESA
 #
-# (C) 2018 Volvo Cars
-# (C) 2016 Jaguar Land Rover
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
-#
+# SPDX-License-Identifier: MPL-2.0
 
 #
 # Generic signals to control movable items such as door, sunroof, window, blind, etc.

--- a/spec/include/PowerOptimize.vspec
+++ b/spec/include/PowerOptimize.vspec
@@ -1,9 +1,7 @@
-#
-# (C) 2023 Robert Bosch GmbH
+## Copyright (c) 2023 Contributors to COVESA
 #
 # All files and artifacts in this repository are licensed under the
 # provisions of the license provided by the LICENSE file in this repository.
-#
 
 #
 # Architectural Concept

--- a/spec/include/PowerOptimize.vspec
+++ b/spec/include/PowerOptimize.vspec
@@ -1,7 +1,10 @@
-## Copyright (c) 2023 Contributors to COVESA
+# Copyright (c) 2023 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
 
 #
 # Architectural Concept


### PR DESCRIPTION
Fixes #632

As discussed in the issue, this PR intends to unify and simplify copyright handling. It is inspired by https://www.eclipse.org/projects/handbook/#ip-copyright-headers. One difference is that we are not referencing to a NOTICE.md file. Eclipse often do so, in that the file they state:

_All content is the property of the respective authors or their employers.
For more information regarding authorship of content, please consult the
listed source code repository logs._

As this concerns copyright statements we should possibly consult TST or Board (FYI @paulboyes ) and get their approval before merging, but the first step is to discuss if we from a technical/practical perspective thinks this a reasonable change.

