### PR TITLE
Bump JamesIves/github-pages-deploy-action to 4.4.3

### DIFF
--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Deploy docs
         # Only deploy docs if this was a push to master
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-        uses: JamesIves/github-pages-deploy-action@4.1.4
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: docs # The folder the action should deploy.


### PR DESCRIPTION
Needed to start using Node.js 16 instead of 12 which is deprecated

See release notes at https://github.com/JamesIves/github-pages-deploy-action/releases
As this action only is used at merge we cannot easily test it until it has been merged