### PR TITLE
Refactoring unit file

### DIFF
--- a/docs-gen/content/rule_set/data_entry/data_unit_types.md
+++ b/docs-gen/content/rule_set/data_entry/data_unit_types.md
@@ -28,7 +28,7 @@ But in protocols not explicitly specifying data units (like [VISS](https://raw.g
 it is expected that `Vehicle.Speed` is sent and received as `km/h` (without scaling or offset).
 
 In some cases it is natural to omit the data unit. This concerns typically signals where datatype `string` is used,
-but also signals where the value just represents a number, like in the example below:
+but also signals where the value just represents a number (dimensionless quantities), like in the example below:
 
 ```
 Vehicle.Cabin.DoorCount:
@@ -74,67 +74,133 @@ Vehicle.Powertrain.Transmission.ClutchWear:
 
 ## List of supported Data Unit
 
-This list composed with definition according to International Units (SI) and few automotive specific units: [Specification](https://www.iso.org/standard/30669.html), [Wikipedia](https://en.wikipedia.org/wiki/International_System_of_Units)
-
-
-Unit          | Domain                          | Description
-:-------------|:--------------------------------|:-------------
-mm            | Distance                        | Distance measured in millimeters
-cm            | Distance                        | Distance measured in centimeters
-m             | Distance                        | Distance measured in meters
-km            | Distance                        | Distance measured in kilometers
-inch          | Distance                        | Distance measured in inches
-km/h          | Speed                           | Speed measured in kilometers per hours
-m/s           | Speed                           | Speed measured in meters per second
-m/s^2         | Acceleration                    | Acceleration measured in meters per second squared
-cm/s^2        | Acceleration                    | Acceleration measured in centimeters per second squared
-ml            | Volume                          | Volume measured in milliliters
-l             | Volume                          | Volume measured in liters
-cm^3          | Volume                          | Volume measured in cubic centimeters
-celsius       | Temperature                     | Temperature measured in degree celsius
-degrees       | Angle                           | Angle measured in degrees
-degrees/s     | Angular Speed                   | Angular speed measured in degrees per second
-W             | Power                           | Power measured in watts
-kW            | Power                           | Power measured in kilowatts
-PS            | Power                           | Power measured in horsepower
-kWh           | Energy Consumption              | Energy consumption measured in kilowatt hours
-g             | Weight                          | Mass measured in grams
-kg            | Weight                          | Mass measured in kilograms
-lbs           | Weight                          | Mass measured in pounds
-V             | Electric Potential              | Electric potential measured in volts
-A             | Electric Current                | Electric current measured in amperes
-Ah            | Electric Charge                 | Electric charge measured in ampere hours
-ms            | Time                            | Time measured in milliseconds
-s             | Time                            | Time measured in seconds
-min           | Time                            | Time measured in minutes
-h             | Time                            | Time measured in hours
-day           | Time                            | Time measured in days
-weeks         | Time                            | Time measured in weeks
-months        | Time                            | Time measured in months
-years         | Time                            | Time measured in years
-UNIX Timestamp| Time                            | Unix time is a system for describing a point in time. It is the number of seconds that have elapsed since the Unix epoch, excluding leap seconds.
-mbar          | Pressure                        | Pressure measured in millibars
-Pa            | Pressure                        | Pressure measured in pascal
-kPa           | Pressure                        | Pressure measured in kilopascal
-stars         | Rating                          | Rating measured in stars
-g/s           | Mass per time                   | Mass per time measured in grams per second
-g/km          | Mass per distance               | Mass per distance measured in grams per kilometers
-kWh/100km     | Energy Consumption per distance | Energy consumption per distance measured in kilowatt hours per 100 kilometers
-ml/100km      | Volume per distance             | Volume per distance measured in milliliters per 100 kilometers
-l/100km       | Volume per distance             | Volume per distance measured in liters per 100 kilometers
-l/h           | Flow                            | Flow measured in liters per hour
-mpg           | Distance per Volume             | Distance per volume measured in miles per gallon
-N             | Force                           | Force measured in newton
-Nm            | Torque                          | Torque measured in newton meters
-rpm           | Rotational Speed                | Rotational speed measured in revolutions per minute
-Hz            | Frequency                       | Frequency measured in hertz
-ratio         | Relation                        | Relation measured as ratio
-percent       | Relation                        | Relation measured in percent
-... | ... | ...
-
-[VSS-Tools](https://github.com/COVESA/vss-tools) require that a unit file is available when transforming *.vspec files.
-It can be specified by the `-u` parameter, and if not given the tools will search for a file `units.yaml`
+The VSS syntax does not in itself specify what units can be used, the unit attribute as declared for signals in *.vspec files is optional and can contain an arbitrary string value.
+[VSS-Tools](https://github.com/COVESA/vss-tools) however require that all units used are defined.
+Units are defined by including them in a unit file with syntax as described below.
+One or more unit files can be specified by the `-u` parameter and, if not given, the tools search for a file `units.yaml`
 in the same directory as the root *.vspec file.
 
-The VSS standard catalog is based on [units.yaml](https://github.com/COVESA/vehicle_signal_specification/blob/master/spec/units.yaml),
-i.e. only units from that file can be used.
+For the VSS standard catalog the VSS-project has defined a set of units that can be used for signals in the VSS standard catalog.
+This list is composed of definitions according to International Units (SI) and few automotive-specific units:
+[Specification](https://www.iso.org/standard/30669.html), [Wikipedia](https://en.wikipedia.org/wiki/International_System_of_Units)
+
+The VSS list of units for the standard catalog exists in [units.yaml](https://github.com/COVESA/vehicle_signal_specification/blob/master/spec/units.yaml).
+
+
+## Unit file syntax
+
+Unit files follow the syntax defined below:
+
+```
+[
+ <vss-unit-identifier>: # Typically unit abbreviation, like km/h or mm, but
+    definition: <string>
+    [unit: <string>] # Full name of unit, optional, if not given assumed to be equal to vss-unit-identifier
+    quantity: <string> # Quantity of the unit.
+    [allowed-datatypes] : ['numeric', 'string', uint8', ...]] # Allowed datatypes in VSS standard catalog
+    [deprecation: <reason>]
+]*
+```
+
+The VSS term `quantity` corresponds roughly to the term `quantity` as defined in for example ISO 80000.
+Typical example are `length`, `mass` and `velocity` that all can be expressed in SI-units.
+However, from a VSS perspective quantities do not need to correspond to physical quantities.
+It could be an arbitrary term, but it is generally expected that it is possible to convert between values
+using different units but defined with the same quantity.
+
+Example:
+
+```
+m:
+  definition: Length measured in meters
+  unit: meter
+  quantity: length
+  allowed-datatypes: ['numeric']
+
+mm:
+  definition: Length measured in millimeters
+  unit: millimeter
+  quantity: length
+  allowed-datatypes: ['numeric']
+```
+
+As `m` and `mm` are defined with the same quantity it is expected that you can convert a value from `m` to `mm`.
+
+The `allowed-datatypes` attributes can be used to specify which VSS datatypes can contain values of a particular unit.
+For most units the symbolic datatype `numeric` meaning any float or integer datatype can be used.
+As an example, both `uint8` and `float` can be used to represent a length value.
+If using `uint8` you will have range restrictions, but that might be acceptable for some signals.
+For some units more specific datatype restrictions are relevant. Some examples:
+
+* A date/time expressed in ISO 8061 format can only be represented as a string
+* A UNIX Timestamp signal must be at least 32 bit unsigned to be able to handle date/time after year 2038.
+
+The `deprecation` keyword can be used to indicate that a specific unit may be removed in the future.
+Tooling shall preferably give a warning if a signal uses a deprecated unit or the unit used belongs to a deprecated quantity.
+The reason should preferably list when and why the unit is deprecated, a hypothetical example is given below:
+
+```
+
+  inch:
+    definition: Distance measured in inches
+    unit: inch
+    quantity: distance
+    deprecation: V5.0 replaced by 'in'
+  in:
+    definition: Distance measured in inches
+    unit: inch
+    quantity: distance
+```
+
+
+The unit syntax has recently been changed. To simplify transition to the new syntax it is recommended that
+tooling also supports unit files using the old syntax described below.
+
+```
+units:
+  [
+    <vss-unit-identifier>: # Typically unit abbreviation, like km/h or mm, but
+      label: <string> # Replaced with "unit"
+      description: <string> # Replaced with "definition"
+      quantity: <string>
+  ]*
+```
+
+## Quantity file syntax
+
+
+Defing quantities is recommended, but currently optional for backward compatibility reasons.
+If tooling supports quantity files it can verify that all units provided in unit files
+use defined quantities.
+
+``
+
+  [
+    <vss-quantity-identifier>: # Identifier preferably taken from a standard, like ISO 80000
+      definition: <string>
+      [remark: <string>] # remark as defined in for example ISO 80000
+      [comment: <string>]
+      [deprecation: <reason>]
+  ]*
+
+```
+
+
+The VSS list of quantitiess for the standard catalog exists in [quantities.yaml](https://github.com/COVESA/vehicle_signal_specification/blob/master/spec/quantities.yaml).
+
+## Defining custom units
+
+It is possible to define custom units in a unit file.
+Assume for instance you want to have a signal showing remaining range in [furlong](https://en.wikipedia.org/wiki/Furlong).
+Then you could add an additional unit `furlong`. No need to specify `unit` or `symbol` as they equals the default (i.e. "furlong").
+As this is unit not commonly used and not described in any standards, it might be relevant to describe how it can be converted to other units.
+That is however only informative, as it a custom unit a downstream implementation supporting unit conversion may not support automatic conversion
+of furlong to other units.
+
+```
+units:
+  furlong:
+    definition: Length measured in furlong, 1 furlong equals 201.1680 m
+    quantity: length
+    allowed-datatypes: ['numeric']
+```

--- a/spec/Cabin/Infotainment.vspec
+++ b/spec/Cabin/Infotainment.vspec
@@ -234,6 +234,7 @@ HMI.IsScreenAlwaysOn:
 HMI.LastActionTime:
   datatype: string
   type: sensor
+  unit: iso8601
   description: Time for last hmi action, formatted according to ISO 8601 with UTC time zone.
 
 HMI.DisplayOffDuration:

--- a/spec/Powertrain/TractionBattery.vspec
+++ b/spec/Powertrain/TractionBattery.vspec
@@ -21,6 +21,7 @@ Id:
 ProductionDate:
   datatype: string
   type: attribute
+  unit: iso8601
   description: Production date of battery in ISO8601 format, e.g. YYYY-MM-DD.
 
 ErrorCodes:
@@ -570,6 +571,7 @@ Charging.Timer.Mode:
 Charging.Timer.Time:
   datatype: string
   type: actuator
+  unit: iso8601
   description: Time for next charging-related action, formatted according to ISO 8601 with UTC time zone.
                Value has no significance if Charging.Timer.Mode is 'inactive'.
 

--- a/spec/Vehicle/Vehicle.vspec
+++ b/spec/Vehicle/Vehicle.vspec
@@ -97,6 +97,7 @@ VehicleIdentification.BodyType:
 VehicleIdentification.DateVehicleFirstRegistered:
   datatype: string
   type: attribute
+  unit: iso8601
   description: The date in ISO 8601 format of the first registration of the vehicle with the respective public authorities.
 
 VehicleIdentification.LicensePlate:
@@ -113,16 +114,19 @@ VehicleIdentification.MeetsEmissionStandard:
 VehicleIdentification.ProductionDate:
   datatype: string
   type: attribute
+  unit: iso8601
   description: The date in ISO 8601 format of production of the item, e.g. vehicle.
 
 VehicleIdentification.PurchaseDate:
   datatype: string
   type: attribute
+  unit: iso8601
   description: The date in ISO 8601 format of the item e.g. vehicle was purchased by the current owner.
 
 VehicleIdentification.VehicleModelDate:
   datatype: string
   type: attribute
+  unit: iso8601
   description: The release date in ISO 8601 format of a vehicle model (often used to differentiate versions of the same make and model).
 
 VehicleIdentification.VehicleConfiguration:
@@ -217,6 +221,7 @@ StartTime:
   datatype: string
   type: attribute
   default: '0000-01-01T00:00Z'
+  unit: iso8601
   description: Start time of current or latest trip, formatted according to ISO 8601 with UTC time zone.
   comment: This signal is supposed to be set whenever a new trip starts.
            A new trip is considered to start when engine gets enabled (e.g. LowVoltageSystemState in ON or START mode).
@@ -447,6 +452,7 @@ CurrentLocation:
 CurrentLocation.Timestamp:
   datatype: string
   type: sensor
+  unit: iso8601
   description: Timestamp from GNSS system for current location, formatted according to ISO 8601 with UTC time zone.
 
 CurrentLocation.Latitude:

--- a/spec/quantities.yaml
+++ b/spec/quantities.yaml
@@ -1,0 +1,80 @@
+# This file defines available quantities for the units defined for the VSS standard catalog in the file unit.yaml.
+# See VSS documentation for information on syntax and intended content
+
+length:
+  definition: Linear extent in space between any two points (ISO 80000-3:2019)
+  remark: Length does not need to be measured along a straight line.
+          Length is one of the seven base quantities in the International System of Units (ISO 80000-1).
+velocity:
+  definition: Vector quantity giving the rate of change of a position vector (ISO 80000-3:2019)
+acceleration:
+  definition: Vector quantity giving the rate of change of velocity (ISO 80000-3:2019)
+volume:
+  definition: Extent of a three‑dimensional geometrical shape (ISO 80000-3:2019)
+temperature:
+  definition: Partial derivative of internal energy with respect to entropy at constant volume
+              and constant number of particles in the system (ISO 80000-3:2019)
+angle:
+  definition: TBD
+angular-speed:
+  definition: TBD
+power:
+  definition: Scalar product of force F acting to a body and its velocity (ISO 80000-4:2019)
+work:
+  definition: Process quantity describing the total action of a force F along a continuous curve
+              in three-dimensional space with infinitesimal displacement dr,
+              as a line integral of their scalar product (ISO 80000-4:2019)
+mass:
+  definition: Property of a body which expresses itself in terms of inertia
+              related to changes in its state of motion as well as
+              its gravitational attraction to other bodies (ISO 80000-4:2019)
+voltage:
+  definition: For a conductor, scalar quantity given by the
+              electric potential difference Vab (6-11.2) between
+              two points a and b respectively (IEC 80000-6:2022)
+electric-current:
+  definition: Scalar quantity equal to the quotient of the net
+              quasi-infinitesimal electric charge dQ
+              transferred through a surface during a quasiinfinitesimal
+              time interval and the duration dt of that interval (IEC 80000-6:2022)
+electric-charge:
+  definition: Additive scalar quantity attributed to any particle
+              and, generally, any system of them, to
+              characterize its electromagnetic interactions (IEC 80000-6:2022)
+duration:
+  definition: Measure of the time difference between two events (ISO 80000-3:2019)
+datetime:
+  definition: Specific point in time
+  remark: This quantity is not described in ISO 80000.
+  comment: Example usage of this quantity could be ISO 8601 string representation of date and time, or UNIX timestamp
+pressure:
+  definition: Quotient of the component of a force normal to a surface and its area (ISO 80000-4:2019)
+rating:
+  definition: TBD
+mass-per-time:
+  definition: TBD
+mass-per-distance:
+  definition: TBD
+energy-consumption-per-distance:
+  definition: TBD
+volume-per-distance:
+  definition: TBD
+volume-flow-rate:
+  definition: Scalar quantity characterizing the total flow through the two-dimensional domain A with
+              the normal vector en of a flowing fluid with velocity v as an integral (ISO 80000-4:2019)
+distance-per-volume:
+  definition: TBD
+force:
+  definition: Vector quantity describing interaction between bodies or particles (ISO 80000-4:2019)
+torque:
+  definition: quantity described by the scalar product M*eQ where M is moment of force and eQ is
+rotational-speed:
+  definition: TBD
+frequency:
+  definition: TBD
+relation:
+  definition: Dimensionsless quantity for relation between two values of the same quantity.
+  remark: This quantity is not described in ISO 80000.
+resistance:
+  definition: Property of a resistive element, equal to the scalar
+            quantity given by the quotient of voltage u and electric current i (IEC 80000-6:2022)

--- a/spec/units.yaml
+++ b/spec/units.yaml
@@ -1,238 +1,389 @@
 # This file defines units supported in the VSS standard catalog
-units:
-  mm:
-    label: millimeter
-    description: Distance measured in millimeters
-    domain: distance
-  cm:
-    label: centimeter
-    description: Distance measured in centimeters
-    domain: distance
-  m:
-    label: meter
-    description: Distance measured in meters
-    domain: distance
-  km:
-    label: kilometer
-    description: Distance measured in kilometers
-    domain: distance
-  inch:
-    label: inch
-    description: Distance measured in inches
-    domain: distance
-  km/h:
-    label: kilometer per hour
-    description: Speed measured in kilometers per hours
-    domain: speed
-  m/s:
-    label: meters per second
-    description: Speed measured in meters per second
-    domain: speed
-  m/s^2:
-    label: meters per second squared
-    description: Acceleration measured in meters per second squared
-    domain: acceleration
-  cm/s^2:
-    label: centimeters per second squared
-    description: Acceleration measured in centimeters per second squared
-    domain: acceleration
-  ml:
-    label: milliliter
-    description: Volume measured in milliliters
-    domain: volume
-  l:
-    label: liter
-    description: Volume measured in liters
-    domain: volume
-  cm^3:
-    label: cubic centimeters
-    description: Volume measured in cubic centimeters
-    domain: volume
-  celsius:
-    label: degree celsius
-    description: Temperature measured in degree celsius
-    domain: temperature
-  degrees:
-    label: degree
-    description: Angle measured in degrees
-    domain: angle
-  degrees/s:
-    label: degree per second
-    description: Angular speed measured in degrees per second
-    domain: angular speed
-  W:
-    label: watt
-    description: Power measured in watts
-    domain: power
-  kW:
-    label: kilowatt
-    description: Power measured in kilowatts
-    domain: power
-  PS:
-    label: horsepower
-    description: Power measured in horsepower
-    domain: power
-  kWh:
-    label: kilowatt hours
-    description: Energy consumption measured in kilowatt hours
-    domain: energy consumption
-  g:
-    label: gram
-    description: Mass measured in grams
-    domain: mass
-  kg:
-    label: kilogram
-    description: Mass measured in kilograms
-    domain: mass
-  lbs:
-    label: pound
-    description: Mass measured in pounds
-    domain: mass
-  V:
-    label: volt
-    description: Electric potential measured in volts
-    domain: electric potential
-  A:
-    label: ampere
-    description: Electric current measured in amperes
-    domain: electric current
-  Ah:
-    label: ampere hours
-    description: Electric charge measured in ampere hours
-    domain: electric charge
-  ms:
-    label: millisecond
-    description: Time measured in milliseconds
-    domain: time
-  s:
-    label: second
-    description: Time measured in seconds
-    domain: time
-  min:
-    label: minute
-    description: Time measured in minutes
-    domain: time
-  h:
-    label: hour
-    description: Time measured in hours
-    domain: time
-  day:
-    label: days
-    description: Time measured in days
-    domain: time
-  weeks:
-    label: weeks
-    description: Time measured in weeks
-    domain: time
-  months:
-    label: months
-    description: Time measured in months
-    domain: time
-  years:
-    label: years
-    description: Time measured in years
-    domain: time
-  UNIX Timestamp:
-    label: UNIX Timestamp
-    description: Unix time is a system for describing a point in time. It is the number of seconds that have elapsed since the Unix epoch, excluding leap seconds.
-    domain: point in time
-  mbar:
-    label: millibar
-    description: Pressure measured in millibars
-    domain: pressure
-  Pa:
-    label: pascal
-    description: Pressure measured in pascal
-    domain: pressure
-  kPa:
-    label: kilopascal
-    description: Pressure measured in kilopascal
-    domain: pressure
-  stars:
-    label: stars
-    description: Rating measured in stars
-    domain: rating
-  g/s:
-    label: grams per second
-    description: Mass per time measured in grams per second
-    domain: mass per time
-  g/km:
-    label: grams per kilometer
-    description: Mass per distance measured in grams per kilometers
-    domain: mass per distance
-  kWh/100km:
-    label: kilowatt hours per 100 kilometers
-    description: Energy consumption per distance measured in kilowatt hours per 100 kilometers
-    domain: energy consumption per distance
-  ml/100km:
-    label: milliliter per 100 kilometers
-    description: Volume per distance measured in milliliters per 100 kilometers
-    domain: volume per distance
-  l/100km:
-    label: liter per 100 kilometers
-    description: Volume per distance measured in liters per 100 kilometers
-    domain: volume per distance
-  l/h:
-    label: liter per hour
-    description: Flow measured in liters per hour
-    domain: flow
-  mpg:
-    label: miles per gallon
-    description: Distance per volume measured in miles per gallon
-    domain: distance per volume
-  N:
-    label: newton
-    description: Force measured in newton
-    domain: force
-  Nm:
-    label: newton meter
-    description: Torque measured in newton meters
-    domain: torque
-  rpm:
-    label: revolutions per minute
-    description: Rotational speed measured in revolutions per minute
-    domain: rotational speed
-  Hz:
-    label: frequency
-    description: Frequency measured in hertz
-    domain: frequency
-  ratio:
-    label: ratio
-    description: Relation measured as ratio
-    domain: relation
-  percent:
-    label: percent
-    description: Relation measured in percent
-    domain: relation
-  nm/km:
-    label: nano meter per kilometer
-    description: nm/km
-    domain: nm/km
-  dBm:
-    label: decibel milliwatt
-    description: Power level expressed in decibels with reference to one milliwatt
-    domain: relation
-  kN:
-    label: kilo newton
-    description: Force measured in kilo newton
-    domain: force
-  cpm:
-    label: cycles per minute
-    description: Number of cycles per minute
-    domain: frequency
-  bpm:
-    label: beats per minute
-    description: Number of human heart beats per minute
-    domain: frequency
-  Ohm:
-    label: resistance
-    description: Electrical resistance measured in ohms
-    domain: electric resistance
-  Wh/km:
-    description:  Energy consumption per distance measured in watt hours per  kilometer
-    label: watt hour per km
-    domain: energy consumption per distance
-  psi:
-    description: Pressure measured in pounds per square inch
-    label: pounds per square inch
-    domain: pressure
+# See VSS documentation for information on syntax and intended content
+
+# Length
+
+mm:
+  definition: Length measured in millimeters
+  unit: millimeter
+  quantity: length
+  allowed-datatypes: ['numeric']
+cm:
+  definition: Length measured in centimeters
+  unit: centimeter
+  quantity: length
+  allowed-datatypes: ['numeric']
+m:
+  definition: Length measured in meters
+  unit: meter
+  quantity: length
+  allowed-datatypes: ['numeric']
+km:
+  definition: Length measured in kilometers
+  unit: kilometer
+  quantity: length
+  allowed-datatypes: ['numeric']
+inch:
+  definition: Distance measured in inches
+  unit: inch
+  quantity: length
+  allowed-datatypes: ['numeric']
+
+# Velocity
+
+km/h:
+  definition: Velocity measured in kilometers per hours
+  unit: kilometer per hour
+  quantity: velocity
+  allowed-datatypes: ['numeric']
+m/s:
+  definition: Speed measured in meters per second
+  unit: meters per second
+  quantity: velocity
+  allowed-datatypes: ['numeric']
+
+# Acceleration
+
+m/s^2:
+  definition: Acceleration measured in meters per second squared
+  unit: meters per second squared
+  quantity: acceleration
+  allowed-datatypes: ['numeric']
+cm/s^2:
+  definition: Acceleration measured in centimeters per second squared
+  unit: centimeters per second squared
+  quantity: acceleration
+  allowed-datatypes: ['numeric']
+
+# Volume
+
+ml:
+  description: Volume measured in milliliters
+  unit: milliliter
+  quantity: volume
+  allowed-datatypes: ['numeric']
+l:
+  definition: Volume measured in liters
+  unit: liter
+  quantity: volume
+  allowed-datatypes: ['numeric']
+cm^3:
+  definition: Volume measured in cubic centimeters
+  unit: cubic centimeters
+  quantity: volume
+  allowed-datatypes: ['numeric']
+
+# Temperature
+
+celsius:
+  definition: Temperature measured in degree celsius
+  unit: degree celsius
+  quantity: temperature
+  allowed-datatypes: ['numeric']
+
+# Angle
+
+degrees:
+  definition: Angle measured in degrees
+  unit: degree
+  quantity: angle
+  allowed-datatypes: ['numeric']
+
+# Angular Speed
+
+degrees/s:
+  definition: Angular speed measured in degrees per second
+  unit: degree per second
+  quantity: angular-speed
+  allowed-datatypes: ['numeric']
+
+# Power
+
+W:
+  definition: Power measured in watts
+  unit: watt
+  quantity: power
+  allowed-datatypes: ['numeric']
+kW:
+  definition: Power measured in kilowatts
+  unit: kilowatt
+  quantity: power
+  allowed-datatypes: ['numeric']
+PS:
+  definition: Power measured in horsepower
+  unit: horsepower
+  quantity: power
+  allowed-datatypes: ['numeric']
+
+# Work
+
+kWh:
+  definition: Energy consumption measured in kilowatt hours
+  unit: kilowatt hours
+  quantity: work
+  allowed-datatypes: ['numeric']
+
+# Mass
+
+g:
+  definition: Mass measured in grams
+  unit: gram
+  quantity: mass
+  allowed-datatypes: ['numeric']
+kg:
+  definition: Mass measured in kilograms
+  label: kilogram
+  quantity: mass
+  allowed-datatypes: ['numeric']
+lbs:
+  definition: Mass measured in pounds
+  unit: pound
+  quantity: mass
+  allowed-datatypes: ['numeric']
+
+# Voltage
+
+V:
+  definition: Electric potential measured in volts
+  unit: volt
+  quantity: voltage
+  allowed-datatypes: ['numeric']
+
+# Electric Current
+
+A:
+  definition: Electric current measured in amperes
+  unit: ampere
+  quantity: electric-current
+  allowed-datatypes: ['numeric']
+
+# Electric Charge
+
+Ah:
+  definition: Electric charge measured in ampere hours
+  unit: ampere hours
+  quantity: electric-charge
+  allowed-datatypes: ['numeric']
+
+# Duration
+
+ms:
+  definition: Duration measured in milliseconds
+  unit: millisecond
+  quantity: duration
+  allowed-datatypes: ['numeric']
+s:
+  definition: Duration measured in seconds
+  unit: second
+  quantity: duration
+  allowed-datatypes: ['numeric']
+min:
+  unit: minute
+  definition: Duration measured in minutes
+  quantity: duration
+  allowed-datatypes: ['numeric']
+h:
+  definition: Duration measured in hours
+  unit: hour
+  quantity: duration
+  allowed-datatypes: ['numeric']
+day:
+  definition: Duration measured in days
+  unit: days
+  quantity: duration
+  allowed-datatypes: ['numeric']
+weeks:
+  definition: Duration measured in weeks
+  unit: weeks
+  quantity: duration
+  allowed-datatypes: ['numeric']
+months:
+  definition: Duration measured in months
+  units: months
+  quantity: duration
+  allowed-datatypes: ['numeric']
+years:
+  definition: Duration measured in years
+  unit: years
+  quantity: duration
+  allowed-datatypes: ['numeric']
+
+# Datetime
+
+unix-time:
+  definition: Number of non-leap seconds which have passed since 00:00:00 UTC on Thursday, 1 January 1970
+  unit: UNIX Timestamp
+  quantity: datetime
+  allowed-datatypes: ['uint32','uint64','int64']
+iso8601:
+  definition: Date and Time expressed as a string according to ISO 8601
+  unit: ISO 8601
+  quantity: datetime
+  allowed-datatypes: ['string']
+
+# Pressure
+
+mbar:
+  definition: Pressure measured in millibars
+  unit: millibar
+  quantity: pressure
+  allowed-datatypes: ['numeric']
+Pa:
+  definition: Pressure measured in pascal
+  unit: pascal
+  quantity: pressure
+  allowed-datatypes: ['numeric']
+kPa:
+  definition: Pressure measured in kilopascal
+  unit: kilopascal
+  quantity: pressure
+  allowed-datatypes: ['numeric']
+psi:
+  definition: Pressure measured in pounds per square inch
+  unit: pounds per square inch
+  quantity: pressure
+  allowed-datatypes: ['numeric']
+
+# Rating
+
+stars:
+  definition: Rating measured in stars
+  unit: stars
+  quantity: rating
+  allowed-datatypes: ['numeric']
+
+# Mass per time
+
+g/s:
+  definition: Mass per time measured in grams per second
+  unit: grams per second
+  quantity: mass-per-time
+  allowed-datatypes: ['numeric']
+
+# Mass per distance
+
+g/km:
+  definition: Mass per distance measured in grams per kilometers
+  unit: grams per kilometer
+  quantity: mass-per-distance
+  allowed-datatypes: ['numeric']
+
+# Energy consumption per distance
+
+kWh/100km:
+  definition: Energy consumption per distance measured in kilowatt hours per 100 kilometers
+  unit: kilowatt hours per 100 kilometers
+  quantity: energy-consumption-per-distance
+  allowed-datatypes: ['numeric']
+Wh/km:
+  definition:  Energy consumption per distance measured in watt hours per kilometer
+  unit: watt hour per km
+  quantity: energy-consumption-per-distance
+  allowed-datatypes: ['numeric']
+
+# Volume per distance
+
+ml/100km:
+  definition: Volume per distance measured in milliliters per 100 kilometers
+  unit: milliliter per 100 kilometers
+  quantity: volume-per-distance
+  allowed-datatypes: ['numeric']
+l/100km:
+  definition: Volume per distance measured in liters per 100 kilometers
+  unit: liter per 100 kilometers
+  quantity: volume-per-distance
+  allowed-datatypes: ['numeric']
+
+# Volume flow rate
+
+l/h:
+  definition: Flow measured in liters per hour
+  unit: liter per hour
+  quantity: volume-flow-rate
+  allowed-datatypes: ['numeric']
+
+# Distance per volume
+
+mpg:
+  definition: Distance per volume measured in miles per gallon
+  unit: miles per gallon
+  quantity: distance-per-volume
+  allowed-datatypes: ['numeric']
+
+# Force
+
+N:
+  definition: Force measured in newton
+  unit: newton
+  quantity: force
+  allowed-datatypes: ['numeric']
+kN:
+  unit: kilo newton
+  definition: Force measured in kilo newton
+  quantity: force
+  allowed-datatypes: ['numeric']
+
+# Torque
+
+Nm:
+  definition: Torque measured in newton meters
+  unit: newton meter
+  quantity: torque
+  allowed-datatypes: ['numeric']
+
+# Rotational Speed
+
+rpm:
+  definition: Rotational speed measured in revolutions per minute
+  unit: revolutions per minute
+  quantity: rotational-speed
+  allowed-datatypes: ['numeric']
+
+# Frequency
+
+Hz:
+  definition: Frequency measured in hertz
+  unit: Hertz
+  quantity: frequency
+  allowed-datatypes: ['numeric']
+cpm:
+  definition: Number of cycles per minute
+  unit: cycles per minute
+  quantity: frequency
+  allowed-datatypes: ['numeric']
+bpm:
+  definition: Number of human heart beats per minute
+  unit: beats per minute
+  quantity: frequency
+  allowed-datatypes: ['numeric']
+
+# Relation
+
+ratio:
+  definition: Relation measured as ratio
+  unit: ratio
+  quantity: relation
+  allowed-datatypes: ['numeric']
+percent:
+  definition: Relation measured in percent
+  unit: percent
+  quantity: relation
+  allowed-datatypes: ['numeric']
+nm/km:
+  definition: nm/km
+  unit: nano meter per kilometer
+  quantity: relation
+  allowed-datatypes: ['numeric']
+dBm:
+  definition: Power level expressed in decibels with reference to one milliwatt
+  unit: decibel milliwatt
+  quantity: relation
+  allowed-datatypes: ['numeric']
+
+# Resistance
+
+Ohm:
+  definition: Electrical resistance measured in ohms
+  unit: Ohm
+  quantity: resistance
+  allowed-datatypes: ['numeric']


### PR DESCRIPTION
This is a draft for discussion only, partially inspired by #667, partially inspired by discussions at the AMM.

At the AMM we discussed if signals shall have a unit (like km/h) or just a domain/dimension (like speed). With the latter approach it would be possible to send around values with different units, as long as the unit-information is included the receiver can convert it to whatever the user wants. On the other hand, in some APIs/solutions like VISS and KUKSA gRPC unit information is never explicitly included when you get an observation, you just get a value which is assumed to be in the unit defined for that signal

Based on that I come up with some ideas:

-  Should we possibly specify in the VSS unit file how different units like `km/h` and `m/s` relate to each other? Even if it might be easy to understand for a human how to convert between them it might be more difficult for a computer. One way could be to say the we use km/h as default and all other speed units must specify how you they relate to km/h. That would allow for VSS-based solutions to offer solutions where you can get the signal value in whatever VSS unit you want, like `get('Vehicle.Speed', 'm/s')`
- For time it is infeasible to specify how to convert between iso8061 and unix timestamp in the unit file itself, so there one may need to specify that custom (hardcoded) conversion methods must be implemented
- What fields/terms do we actually need for units? Shall we possibly remove "label", it is not used and does not seem to provide much value if we have both name and description.
- Shall we possibly specify supported datatypes for each unit? If we do so the tooling could give an error or warning if you use another datatype. Like combining iso8061 with a numeric type, or a unix timestamp with string or a small integer.

I would like to know your opinion on if this seems to be reasonable direction for improving/extending the unit file. If we agree on that then we can start looking into details. That CI will fail for this PR is expected - as of today "label" is a required property, so if we agree to make it optional we must do a minor change in vss-tools.

_Note: I think there are a lot of things that could be discussed. Like shall we keep the term "domain", or would it be better to call it "dimension" or "quantity" (term used in the NIST document). Similarly would "time" + "duration" be better than "point in time" + "time"._ 


