### PR TITLE
Support negative torque for combustion engine

### DIFF
--- a/spec/Powertrain/CombustionEngine.vspec
+++ b/spec/Powertrain/CombustionEngine.vspec
@@ -223,12 +223,11 @@ Power:
 # Current Torque
 #
 Torque:
-  datatype: uint16
+  datatype: int16
   type: sensor
   unit: Nm
-  description: Current engine torque. Shall be reported as 0 during engine breaking.
+  description: Current engine torque. Shall be reported as a negative number during engine breaking.
   comment: During engine breaking the engine delivers a negative torque to the transmission.
-           This negative torque shall be ignored, instead 0 shall be reported.
 
 #
 # Diesel Exhaust Fluid


### PR DESCRIPTION
Some combustion engine vehicles report a negative torque under braking conditions. This cannot be properly reflected by the current definition of engine torque as it is an unsigned integer.

This change proposes modifying the combustion engine torque definition from an unsigned integer to an integer.

Signed-off-by: Pierre Pierre Blais ppblais@BlackBerry.com