### PR TITLE
Align Temperature Signals

### DIFF
--- a/spec/Powertrain/CombustionEngine.vspec
+++ b/spec/Powertrain/CombustionEngine.vspec
@@ -153,7 +153,7 @@ IdleHours:
 # Engine coolant temperature
 #
 ECT:
-  datatype: int16
+  datatype: float
   type: sensor
   unit: celsius
   description: Engine coolant temperature.
@@ -163,7 +163,7 @@ ECT:
 # Engine Oil Temperature
 #
 EOT:
-  datatype: int16
+  datatype: float
   type: sensor
   unit: celsius
   description: Engine oil temperature.

--- a/spec/Powertrain/ElectricMotor.vspec
+++ b/spec/Powertrain/ElectricMotor.vspec
@@ -57,7 +57,7 @@ Speed:
 # Motor temperature
 #
 Temperature:
-  datatype: int16
+  datatype: float
   type: sensor
   unit: celsius
   description: Motor temperature.
@@ -67,7 +67,7 @@ Temperature:
 # Motor coolant temperature (if applicable)
 #
 CoolantTemperature:
-  datatype: int16
+  datatype: float
   type: sensor
   unit: celsius
   description: Motor coolant temperature (if applicable).

--- a/spec/Powertrain/Transmission.vspec
+++ b/spec/Powertrain/Transmission.vspec
@@ -110,7 +110,7 @@ GearChangeMode:
 # Gearbox temperature
 #
 Temperature:
-  datatype: int16
+  datatype: float
   type: sensor
   unit: celsius
   description: The current gearbox temperature.


### PR DESCRIPTION
As of today we have a mix of float and int16 for temperature signals, with no real rationale for the difference. This PR changes the int16 signals to instead use float, so after this change all signals with Celisus unit use float.

Only intended for VSS 5.0 as this is a backward incompatible change.