### PR TITLE
Feature rule set extensions

### DIFF
--- a/docs-gen/content/rule_set/branches.md
+++ b/docs-gen/content/rule_set/branches.md
@@ -46,8 +46,8 @@ A set of characters that uniquely identifies the branch, usually the full path
 
 **```elementType```** *[optional]* 
 A type that categorizes the branch's role in the vehicle signal domain, or as a Node if the branch exists purely for tree traversal and has no vehicle signal domain signifcance on its own.
-- ```FeatureOfInterest```: A physical object whose properties can be observed and possibly manipulated.
-- ```Node```: A branch in the tree that does not correspond to a domain object.  These are generally used to group related nodes
+- ```FeatureOfInterest``` A physical object whose properties can be observed and possibly manipulated.
+- ```Node``` A branch in the tree that does not correspond to a domain object.  These are generally used to group related nodes.
 
 **```definition```*** [optional]* 
 A formal specification that includes the necessary and sufficient conditions for distinguishing this branch from anything else.  It is similar to a dictionary definition, and the conditions put forth can translate to formal axioms in an ontology and can be used for inferencing and automation.

--- a/docs-gen/content/rule_set/branches.md
+++ b/docs-gen/content/rule_set/branches.md
@@ -5,30 +5,55 @@ weight: 1
 ---
 
 A branch entry describes a tree branch (or node) containing other branches and
-signals.
+signals.  Branches typically represent either a feature of interest (an object whose properties are being observed or reported), or a node that acts as a parent to a group of related properties.
 
-A branch entry example is given below:
+A branch entry representing a feature of interest is exemplified below:
 
 ```YAML
 Trunk:
   type: branch
-  description: All signals related to the rear trunk
-  aggregate: false
+  identifier: Vehicle.Body.Trunk
+  elementType: FeatureOfInterest
+  instances: ["Front", "Rear"]
+  definition: An enclosed lockable storage area in a sedan, coupe, or convertible separate from the passenger cabin
+  description: Trunk status.
+  comment: A trunk is a luggage compartment in a vehicle.
+           Depending on vehicle, it can be either in the front or back of the vehicle.
+           Some vehicles may have trunks both at the front and at the rear of the vehicle.
+```
+
+A branch entry representing a parent node is exemplified below:
+
+```YAML
+Windshield.Wiping:
+  type: branch
+  elementType: Node
+  description: Windshield wiper signals.
 ```
 
 The following elements are defined:
 
-**`Body.Trunk`**
+**`Trunk:`** or **`Windshield.Wiping:`**
 The list element name defines the dot-notated signal name to the signal.
 Please note that all parental branches included in the name must be defined as
-well.
+well.  In the case of ```Trunk```, it is a child of ```Vehicle.Body``` and thus both ```Vehicle``` and ```Vehicle.Body``` need to be defined.
 
 **```type```**
-The value ```branch``` specifies that this is a branch entry (as
-opposed to a signal entry). This is the default, in case ```type``` is omitted.
+The value ```branch``` specifies that this is a branch entry. This is the default, in case ```type``` is omitted.
+
+**```identifier```** *[optional]* 
+A set of characters that uniquely identifies the branch, usually the full path
+
+**```elementType```** *[optional]* 
+A type that categorizes the branch's role in the vehicle signal domain, or as a Node if the branch exists purely for tree traversal and has no vehicle signal domain signifcance on its own.
+- ```FeatureOfInterest```: A physical object whose properties can be observed and possibly manipulated.
+- ```Node```: A physical object whose properties can be observed and possibly manipulated.
+
+**```definition```*** [optional]* 
+A formal specification that includes the necessary and sufficient conditions for distinguishing this branch from anything else.  It is similar to a dictionary definition, and the conditions put forth can translate to formal axioms in an ontology and can be used for inferencing and automation.
 
 **```description```**
-Describes the meaning and content of the branch.
+Describes the meaning and content of the branch.  Descriptions can include any kind of information that helps humans conceptualize the entry, such as examples, physical properties, etc.
 Recommended to start with a capital letter and end with a dot (`.`).
 
 **```comment ```**  *[optional]* `since version 3.0`

--- a/docs-gen/content/rule_set/branches.md
+++ b/docs-gen/content/rule_set/branches.md
@@ -47,7 +47,7 @@ A set of characters that uniquely identifies the branch, usually the full path
 **```elementType```** *[optional]* 
 A type that categorizes the branch's role in the vehicle signal domain, or as a Node if the branch exists purely for tree traversal and has no vehicle signal domain signifcance on its own.
 - ```FeatureOfInterest```: A physical object whose properties can be observed and possibly manipulated.
-- ```Node```: A physical object whose properties can be observed and possibly manipulated.
+- ```Node```: A branch in the tree that does not correspond to a domain object.  These are generally used to group related nodes
 
 **```definition```*** [optional]* 
 A formal specification that includes the necessary and sufficient conditions for distinguishing this branch from anything else.  It is similar to a dictionary definition, and the conditions put forth can translate to formal axioms in an ontology and can be used for inferencing and automation.

--- a/docs-gen/content/rule_set/data_entry/attributes.md
+++ b/docs-gen/content/rule_set/data_entry/attributes.md
@@ -23,9 +23,9 @@ MaxPower:
   datatype: uint16
   type: attribute
   identifier: Vehicle.Powertrain.CombustionEngine.MaxPower
-  elementType: SignalDefinition
+  elementType: SignalType
   featureOfInterest: Vehicle.Powertrain.CombustionEngine
-  property: MaximumPower
+  property: DataProperty.MaximumPower
   default: 0
   unit: kW
   definition: The maximum power that a combustion engine can generate
@@ -49,7 +49,7 @@ A set of characters that uniquely identifies the signal.  This is generally the 
 
 **```elementType```** *[optional]*
 A type that classifies the attribute in regards to the Vehicle Signal domain
-- ```SignalDefinition```: The entry defines a property of a feature of interest.
+- ```SignalType``` The entry defines a property of a feature of interest.
 
 **```featureOfInterest```** *[optional]*
 The identifier of the physical object whose properties can be observed and possibly manipulated by signals of this type

--- a/docs-gen/content/rule_set/data_entry/attributes.md
+++ b/docs-gen/content/rule_set/data_entry/attributes.md
@@ -4,7 +4,7 @@ date: 2019-08-04T12:37:31+02:00
 weight: 40
 ---
 
-An attribute is an entity that has a default value, specified by
+An attribute is a signal definition that has a default value, specified by
 its ```default``` member.
 The standard Vehicle Signal Specification does not include default values for all attributes.
 If a default value has not been specified then the OEM must define a default value matching the actual vehicle.
@@ -22,11 +22,53 @@ Below is an example of a complete attribute describing engine power
 MaxPower:
   datatype: uint16
   type: attribute
+  identifier: Vehicle.Powertrain.CombustionEngine.MaxPower
+  elementType: SignalDefinition
+  featureOfInterest: Vehicle.Powertrain.CombustionEngine
+  property: MaximumPower
   default: 0
   unit: kW
+  definition: The maximum power that a combustion engine can generate
   description: Peak power, in kilowatts, that engine can generate.
 ```
 
+The following elements are defined:
+
+**`MaxPower`**
+The list element name defines the leaf node of the dot-notated signal name, which generally corresponds to the property.
+
+**`datatype:`**
+A classification that prescribes which values a data element can take and what type of mathematical, relational or logical operations 
+can be applied to them.  See [Data Types](/vehicle_signal_specification/rule_set/data_entry/data_types/) 
+
+**```type```**
+The value ```attribute``` specifies that this signal may have a default value.
+
+**```identifier```** *[optional]*
+A set of characters that uniquely identifies the signal.  This is generally the branch and the property.
+
+**```elementType```** *[optional]*
+A type that classifies the attribute in regards to the Vehicle Signal domain
+- ```SignalDefinition```: The entry defines a property of a feature of interest.
+
+**```featureOfInterest```** *[optional]*
+The identifier of the physical object whose properties can be observed and possibly manipulated by signals of this type
+
+**```property```** *[optional]*
+The identifier of the property being reported by signals of this type
+
+**```unit```**
+The unit of measurement that the data entry has. See [Data Unit Types](/vehicle_signal_specification/rule_set/data_entry/data_unit_types/)
+chapter for a list of available unit types.
+
+**```definition```*** *[optional]*
+A formal specification that includes the necessary and sufficient conditions for distinguishing this signal definition from anything else.  It is similar to a dictionary definition, and the conditions put forth can translate to formal axioms in an ontology and can be used for inferencing and automation.
+
+**```description```**
+Describes the meaning and content of the property.  Descriptions can include any kind of information that helps humans conceptualize the entry, such as examples, physical properties, etc.
+Recommended to start with a capital letter and end with a dot (`.`).
+
+**```default```**
 It is possible to give default values also for arrays. In this case square brackets shall be used. The value for each element in the array shall be specified. The size of the array is given by the number of elements specified within the square brackets.
 
 Example 1: Empty Array

--- a/docs-gen/content/rule_set/data_entry/sensor_actuator.md
+++ b/docs-gen/content/rule_set/data_entry/sensor_actuator.md
@@ -9,15 +9,15 @@ Sensors are signals to read values of properties in a vehicle. Values of sensors
 Actuators are used to control the desired value of a property. Some properties in a vehicle cannot change instantly. A typical example is position of a seat or a window. Reading a value of an actuator shall return the current actual value, e.g. the current position of the seat, rather than the wanted/desired position. A typical example could be if someone wants to change the position of a seat from 0 to 100. This can be changed by setting the corresponding actuator to 100. If the actuator is read directly after the set request it will still return 0 as it might take some seconds before the seat reaches the wanted position of 100. If the seat by some reason is blocked or cannot be moved due to safety reasons it might never reach the wanted position. It is up to the vehicle to decide how long time it shall try to reach the desired value and what to do if it needs to give up.
 
 A data entry for a sensor or actuator defines its members. A data
-entry example is given below:
+entry example for a data property is given below:
 
 ```YAML
 Speed:
   type: sensor
   identifier: Vehicle.Speed
-  elementType: SignalDefinition
+  elementType: SignalType
   featureOfInterest: Vehicle
-  property: Speed
+  property: DataProperty.Speed
   description: The vehicle speed.
   definition: The rate of change in the vehicle position per unit of time
   comment: For engine speed see Vehicle.Powertrain.CombustionEngine.Engine.Speed.
@@ -39,13 +39,14 @@ A set of characters that uniquely identifies the signal.  This is generally the 
 
 **```elementType```** *[optional]*
 A type that classifies the attribute in regards to the Vehicle Signal domain
-- ```SignalDefinition```: The entry defines a property of a feature of interest.
+- ```SignalType```: The entry defines a property of a feature of interest.
 
 **```featureOfInterest```** *[optional]*
 The identifier of the physical object whose properties can be observed and possibly manipulated by signals of this type
 
 **```property```** *[optional]*
-The identifier of the property being reported by signals of this type
+The identifier of the data property or object property being reported by signals of this type.
+For data properties, the `property` itself has a `datatype` and optional constraints on `unit`, `min`, and `max`.  Those defined for the signal should correspond or provide some explanation of why they differ.  If `unit`, `min`, or `max` are omitted, they are assumed to default to those defined by the `property`.
 
 **```description```**
 Describes the meaning and content of the signal.
@@ -84,3 +85,21 @@ data entry can be assigned.
 If omitted, the maximum value will be the "Max" value for the given type.
 Cannot be specified if ```allowed``` is defined for the same data entry.
 
+
+A data entry example for an object property is given below:
+```YAML
+AirDistribution:
+  datatype: string
+  type: actuator
+  identifier: Vehicle.Cabin.HVAC.Station.AirDistribution
+  elementType: SignalType
+  featureOfInterest: Vehicle.Cabin.HVAC.Station
+  property: ObjectProperty.VerticalDirection  
+  allowed: ['UP', 'MIDDLE', 'DOWN']
+  description: Direction of airstream
+  definition: The course over which something moves from up to down
+```
+
+**```property```** *[optional]*
+The identifier of the data property or object property being reported by signals of this type.
+For object properties, the `property` itself has a set of `allowed` values.  Those defined for the signal should correspond or provide some explanation of why they differ.  If omitted, they are assumed to default to those defined by the `property`.

--- a/docs-gen/content/rule_set/data_entry/sensor_actuator.md
+++ b/docs-gen/content/rule_set/data_entry/sensor_actuator.md
@@ -14,7 +14,12 @@ entry example is given below:
 ```YAML
 Speed:
   type: sensor
+  identifier: Vehicle.Speed
+  elementType: SignalDefinition
+  featureOfInterest: Vehicle
+  property: Speed
   description: The vehicle speed.
+  definition: The rate of change in the vehicle position per unit of time
   comment: For engine speed see Vehicle.Powertrain.CombustionEngine.Engine.Speed.
   datatype: float
   unit: km/h
@@ -22,17 +27,25 @@ Speed:
   max: 300
 ```
 
-**```Drivetrain.Transmission.Speed```**
+**```Speed```**
 Defines the dot-notated name of the data entry. Please note that
 all parental branches included in the name must be defined as well.
 
 **```type```**
-Defines the type of the node. This can be `branch`,
-`sensor`, `actuator` or `attribute`.
+Defines the type of the node.
 
-**```datatype```**
-The string value of the type specifies the scalar type of the data entry
-value. See [data type](/vehicle_signal_specification/rule_set/data_entry/data_types/) chapter for a list of available types.
+**```identifier```** *[optional]*
+A set of characters that uniquely identifies the signal.  This is generally the branch and the property.
+
+**```elementType```** *[optional]*
+A type that classifies the attribute in regards to the Vehicle Signal domain
+- ```SignalDefinition```: The entry defines a property of a feature of interest.
+
+**```featureOfInterest```** *[optional]*
+The identifier of the physical object whose properties can be observed and possibly manipulated by signals of this type
+
+**```property```** *[optional]*
+The identifier of the property being reported by signals of this type
 
 **```description```**
 Describes the meaning and content of the signal.
@@ -40,11 +53,24 @@ The `description`shall together with other mandatory members like `datatype` and
 to understand what the signal contains and how signal values shall be constructed or interpreted.
 Recommended to start with a capital letter and end with a dot (`.`).
 
+
+**```definition```*** *[optional]*
+A formal specification that includes the necessary and sufficient conditions for distinguishing this signal definition from anything else.  It is similar to a dictionary definition, and the conditions put forth can translate to formal axioms in an ontology and can be used for inferencing and automation.
+
 **```comment ```**  *[optional]* `since version 3.0`
 A comment can be used to provide additional informal information on a signal.
 This could include background information on the rationale for the signal design,
 references to related signals, standards and similar.
 Recommended to start with a capital letter and end with a dot (`.`).
+
+**```datatype```**
+The string value of the type specifies the scalar type of the data entry
+value. See [data type](/vehicle_signal_specification/rule_set/data_entry/data_types/) chapter for a list of available types.
+
+**```unit```** *[optional]*
+The unit of measurement that the data entry has. See [Data Unit Types](/vehicle_signal_specification/rule_set/data_entry/data_unit_types/)
+chapter for a list of available unit types. This
+cannot be specified if ```allowed``` is defined as the signal type.
 
 **```min```** *[optional]*
 The minimum value, within the interval of the given ```type```, that the
@@ -58,7 +84,3 @@ data entry can be assigned.
 If omitted, the maximum value will be the "Max" value for the given type.
 Cannot be specified if ```allowed``` is defined for the same data entry.
 
-**```unit```** *[optional]*
-The unit of measurement that the data entry has. See [Data Unit Types](/vehicle_signal_specification/rule_set/data_entry/data_unit_types/)
-chapter for a list of available unit types. This
-cannot be specified if ```allowed``` is defined as the signal type.

--- a/docs-gen/content/rule_set/properties.md
+++ b/docs-gen/content/rule_set/properties.md
@@ -8,12 +8,12 @@ A property entry describes an attribute, quality, or characteristic of a feature
 - ```DataProperty```: A property whose values are literals
 - ```ObjectProperty```: A property whose values are an object, often represented as an element in an enumeration
 
-A ```data property``` entry is exemplified below.  A data property is constrained by a datatype and, optionally, unit, min, and/or max.
+A ```data property``` entry is exemplified below.  A data property is constrained by a datatype and (optionally) unit, min, and/or max.
 
 ```YAML
-RotationalSpeedPercent:
-  type: property
-  identifier: RotationalSpeedPercent
+DataProperty.RotationalSpeedPercent:
+  type: dataProperty
+  identifier: DataProperty.RotationalSpeedPercent
   elementType: DataProperty
   datatype: uint8
   unit: percent
@@ -27,12 +27,11 @@ RotationalSpeedPercent:
 
 The following elements are defined:
 
-**`RotationalSpeedPercent:`**
-The list element name defines the property identifier.  There is no dot notation 
-as properties are reusable stand-alone elements.  
+**`DataProperty.RotationalSpeedPercent:`**
+The list element name defines the property identifier.  Properties are identified by their element type and name.  
 
 **```type```**
-The value ```property``` specifies that this is a property entry.
+The value ```dataProperty``` specifies that this is a data property entry.
 
 **```identifier```**
 A set of characters that uniquely identifies the property.  This is redundant to the heading and added for consistency with branches and signals.
@@ -70,20 +69,19 @@ Recommended to start with a capital letter and end with a dot (`.`).
 An ```object property``` entry is exemplified below.  The ```allowed``` field enumerates the possible values.
 
 ```YAML
-VerticalOrientation:
-  type: property
-  identifier: VerticalOrientation
+ObjectProperty.VerticalOrientation:
+  type: objectProperty
+  identifier: ObjectProperty.VerticalOrientation
   elementType: ObjectProperty
   allowed: ['UP', 'MIDDLE', 'DOWN']
   definition: An ordinal category indicating a position on, or direction of, the z (vertical) axis
   description: Typical examples include whether a vent it pointing up or down, or the pitch of a vehicle
 ```
-**`VerticalOrientation:`**
-The list element name defines the property identifier.  There is no dot notation 
-as properties are reusable stand-alone elements.  
+**`ObjectProperty.VerticalOrientation:`**
+The list element name defines the property identifier.  Properties are identified by their element type and name.  
 
 **```type```**
-The value ```property``` specifies that this is a property entry.
+The value ```objectProperty``` specifies that this is an object property entry.
 
 **```identifier```** 
 A set of characters that uniquely identifies the ```property```.  This is redundant to the heading and added for consistency with branches and signals.

--- a/docs-gen/content/rule_set/properties.md
+++ b/docs-gen/content/rule_set/properties.md
@@ -1,0 +1,105 @@
+---
+title: "Property Entry"
+date: 2023-11-07
+weight: 1
+---
+
+A property entry describes an attribute, quality, or characteristic of a feature of interest. There are two flavors of properties:
+- ```DataProperty```: A property whose values are literals
+- ```ObjectProperty```: A property whose values are an object, often represented as an element in an enumeration
+
+A ```data property``` entry is exemplified below.  A data property is constrained by a datatype and, optionally, unit, min, and/or max.
+
+```YAML
+RotationalSpeedPercent:
+  type: property
+  identifier: RotationalSpeedPercent
+  elementType: DataProperty
+  datatype: uint8
+  unit: percent
+  min: 0
+  max: 100
+  definition: A percent of circular movements around a central axis during a particular
+              time interval compared to the maximum possible or allowed
+  description: The speed of a rotating part, such as the blades in a fan, on a scale of
+               0 to 100 where 0 = still or off, and 100 = max or full
+```
+
+The following elements are defined:
+
+**`RotationalSpeedPercent:`**
+The list element name defines the property identifier.  There is no dot notation 
+as properties are reusable stand-alone elements.  
+
+**```type```**
+The value ```property``` specifies that this is a property entry.
+
+**```identifier```**
+A set of characters that uniquely identifies the property.  This is redundant to the heading and added for consistency with branches and signals.
+
+**```elementType```**
+A type that categorizes whether values for the property are literals or objects.
+- ```DataProperty```: The property takes literals as values.
+- ```ObjectProperty```: The property takes pre-defined objects, such as enumeration elements, as values.
+
+**```datatype```**
+A classification that prescribes which values a data element can take and what type of mathematical, relational or logical operations 
+can be applied to them.  See [Data Types](/vehicle_signal_specification/rule_set/data_entry/data_types/)
+
+**```unit```** *[optional]*
+The unit of measurement that the data entry has. See [Data Unit Types](/vehicle_signal_specification/rule_set/data_entry/data_unit_types/)
+chapter for a list of available unit types. This
+
+**```min```** *[optional]*
+The minimum value, within the interval of the given ```type```, that the
+data entry can be assigned.
+If omitted, the minimum value will be the "Min" value for the given type.
+
+**```max```** *[optional]*
+The maximum value, within the interval of the given ```type```, that the
+data entry can be assigned.
+If omitted, the maximum value will be the "Max" value for the given type.
+
+**```definition```**
+A formal specification that includes the necessary and sufficient conditions for distinguishing this property from anything else.  It is similar to a dictionary definition, and the conditions put forth can translate to formal axioms in an ontology and can be used for inferencing and automation.
+
+**```description```** *[optional]*
+Describes the meaning and content of the property.  Descriptions can include any kind of information that helps humans conceptualize the entry, such as examples, sybmols, usage guidance, etc.
+Recommended to start with a capital letter and end with a dot (`.`).
+
+An ```object property``` entry is exemplified below.  The ```allowed``` field enumerates the possible values.
+
+```YAML
+VerticalOrientation:
+  type: property
+  identifier: VerticalOrientation
+  elementType: ObjectProperty
+  allowed: ['UP', 'MIDDLE', 'DOWN']
+  definition: An ordinal category indicating a position on, or direction of, the z (vertical) axis
+  description: Typical examples include whether a vent it pointing up or down, or the pitch of a vehicle
+```
+**`VerticalOrientation:`**
+The list element name defines the property identifier.  There is no dot notation 
+as properties are reusable stand-alone elements.  
+
+**```type```**
+The value ```property``` specifies that this is a property entry.
+
+**```identifier```** 
+A set of characters that uniquely identifies the ```property```.  This is redundant to the heading and added for consistency with branches and signals.
+
+**```elementType```** 
+A type that categorizes whether values for the property are literals or objects.
+- ```DataProperty```: The property takes literals as values
+- ```ObjectProperty```: The property takes a pre-defined objects, such as enumeration elements, as values.
+
+**```allowed```** 
+The set of values allowed for this object property
+
+**```definition```***
+A formal specification that includes the necessary and sufficient conditions for distinguishing this property from anything else.  It is similar to a dictionary definition, and the conditions put forth can translate to formal axioms in an ontology and can be used for inferencing and automation.
+
+**```description```** [optional]* 
+Describes the meaning and content of the property.  Descriptions can include any kind of information that helps humans conceptualize the entry, such as examples, sybmols, usage guidance, etc.
+Recommended to start with a capital letter and end with a dot (`.`).
+


### PR DESCRIPTION
These extensions to the VSS allow consumers to understand each signal well enough to determine its relation to signals emitted by vehicle components and to downstream client and consumer needs.  Because they are optional extensions permitted by VSS Overlays, they do not break any current code or processes.

The properties.md file describes the promotion of **dataProperty** and **objectProperty** to a first-class types, allowing signals to reference the property they report.

The **elementType ** key provides each entry's classification within the vehicle signal domain, such as SignalDefinition, FeatureOfInterest, Property, etc.

The **identifier ** key provides a unique and immutable key.  This allows restructuring of the tree and the files/folders without any effect on the key.  In my examples I've used the entire path of the entry, but it could be any unique value.  

The **definition ** key provides the necessary and sufficient conditions of the entry which can translate to formal axioms.

The **featureOfInterest** and **property** keys in the attributes, sensors, and actuators explicitly refer to the object being observed or manipulated, and the property being reported.  This is needed not only to aid integration, but to allow analysis, discovery, automation, and inferencing through the graph.

