### PR TITLE
feat: Add decibels as unit.

### DIFF
--- a/spec/units.yaml
+++ b/spec/units.yaml
@@ -379,6 +379,11 @@ dBm:
   unit: decibel milliwatt
   quantity: relation
   allowed-datatypes: ['numeric']
+dB:
+  definition: Ratio of two values of a physical quantity, usually power or intensity, on a logarithmic scale.
+  unit: decibel
+  quantity: relation
+  allowed-datatypes: ['numeric']
 
 # Resistance
 


### PR DESCRIPTION
The unit `decibels` was not part of VSS until now. The only similar unit I found was `dBm`. However, they refer to different things and one cannot make a conversion between them. 