### PR TITLE
Deprecating OBD-branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,4 +197,30 @@ A new version of vss-tools is used, with support for static IDs and jsconschema.
 
 ## Planned Changes VSS 5.0
 
--
+### OBD Branch deprecated
+
+The `Vehicle.OBD` branch is now deprecated. The plan is to remove it in VSS 6.0.
+The background is a decision that VSS standard catalog shall not contain a one-to-one representation of the OBD standard.
+Instead, VSS standard catalog may contain corresponding information elsewhere. As an example, instead of
+`Vehicle.OBD.EngineSpeed` (PID `0C`), the VSS signal `Vehicle.Powertrain.CombustionEngine.Speed` can be used.
+Note that not all signals in `Vehicle.OBD` has "duplicates", especially in the area of combustion engine control
+(like Oxygen sensor lambda and voltage readings) VSS currently does not have any counterparts in other parts of the tree.
+
+
+What to do if you as of today use signals from the OBD file
+
+* Check if any suitable replacement signal exist
+  Example: if you use `Vehicle.OBD.Speed`, consider using `Vehicle.Speed` instead
+* If not and the data may be of general interest; consider creating a pull request
+  with a replacement signal.
+  Example: VSS as of today only have Lambda information in OBD branch
+  If you need VSS signals for Lambda, consider creating new signals in
+  `Vehicle.Powertrain.CombustionEngine` branch.
+* If you really need the signals in this file and cannot replace them, then consider using the overlay file in the
+  `overlays` directory from VSS 6.0 onwards.
+
+## Planned Changes VSS 6.0
+
+### OBD Branch removed
+
+The `Vehicle.OBD` branch is now removed. If needed there is an OBD overlay in the `overlays` directory.

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ ddsidl:
 overlays:
 	${TOOLSDIR}/vspec2json.py -I ./spec --uuid -u ./spec/units.yaml -o overlays/profiles/motorbike.vspec ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION)_motorbike.json
 	${TOOLSDIR}/vspec2json.py -I ./spec --uuid -u ./spec/units.yaml -o overlays/extensions/dual_wiper_systems.vspec ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION)_dualwiper.json
+	${TOOLSDIR}/vspec2json.py -I ./spec --uuid -u ./spec/units.yaml -o overlays/extensions/OBD.vspec ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION)_obd.json
 
 tests:
 	PYTHONPATH=${TOOLSDIR} pytest

--- a/overlays/extensions/OBD.vspec
+++ b/overlays/extensions/OBD.vspec
@@ -1,0 +1,21 @@
+# Copyright (c) 2024 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
+# Overlay to support OBD signals
+# For VSS 5.0 this will be a duplicate of the Vehicle.OBD branch in the standard VSS catalog.
+# From VSS 6.0 onwards the Vehicle.OBD branch in the standard VSS catalog will be removed,
+# and then this overlay must be used if you want to use the VSS signals.
+
+Vehicle:
+  type: branch
+
+Vehicle.OBD:
+  type: branch
+  description: OBD data.
+
+#include OBD/OBD.vspec Vehicle.OBD

--- a/overlays/extensions/OBD/OBD.vspec
+++ b/overlays/extensions/OBD/OBD.vspec
@@ -29,134 +29,97 @@
 #
 #          In VSS the signal contains the actual value, i.e. +4.5 degrees is sent as +4.5.
 #
-# *************** NOTE: THE SIGNALS IN THIS FILE ARE DEPRECATED ************************
-# As discussed in https://github.com/COVESA/vehicle_signal_specification/issues/635
-# all signals in this file are deprecated. VSS intends to remove OBD support in VSS 6.0
-#
-# What to do if you as of today use signals from this file
-# 1. Check if any suitable replacement signal exist
-#    Example: if you use "Vehicle.OBD.Speed", consider using "Vehicle.Speed" instead
-# 2. If not and the data may be of general interest; consider creating a pull request
-#    with a replacement signal.
-#    Example: VSS as of today only have Lambda information in OBD branch
-#    If you need VSS signals for Lambda, consider creating new signals in
-#    Vehicle.Powertrain.CombustionEngine branch.
-# 3. If you really need the signals in this file and cannot replace them
-#    Please let us know - we are always interested in how VSS is used.
-#    A possible work-around is that you maintain a local version of this file,
-#    and when OBD-support is removed from VSS you include your local version of this file as an overlay.
-# *************************************************************************************
-#
-#
-
 
 PidsA:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: string[]
   type: attribute
   allowed: ["01","02","03","04","05","06","07","08","09","0A","0B","0C","0D","0E","0F","10","11","12","13","14","15","16","17","18","19","1A","1B","1C","1D","1E","1F","20"]
   description: PID 00 - Array of the supported PIDs 01 to 20 in Hexadecimal.
 
 PidsB:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: string[]
   type: attribute
   allowed: ["21","22","23","24","25","26","27","28","29","2A","2B","2C","2D","2E","2F","30","31","32","33","34","35","36","37","38","39","3A","3B","3C","3D","3E","3F","40"]
   description: PID 20 - Array of the supported PIDs 21 to 40 in Hexadecimal.
 
 PidsC:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: string[]
   type: attribute
   allowed: ["41","42","43","44","45","46","47","48","49","4A","4B","4C","4D","4E","4F","50","51","52","53","54","55","56","57","58","59","5A","5B","5C","5D","5E","5F","60"]
   description: PID 40 - Array of the supported PIDs 41 to 60 in Hexadecimal.
 
 Status:
-  deprecation: v5.0 OBD-branch is deprecated.
   type: branch
   description: PID 01 - OBD status
 
 Status.IsMILOn:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: boolean
   type: sensor
   description: Malfunction Indicator Light (MIL) False = Off, True = On
 
 Status.DTCCount:
-  deprecation: v5.0 replaced with Vehicle.Diagnostics.DTCCount
   datatype: uint8
   type: sensor
   description: Number of Diagnostic Trouble Codes (DTC)
 
 Status.IgnitionType:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: string
   type: attribute
   allowed: ['SPARK', 'COMPRESSION']
   description: Type of the ignition for ICE - spark = spark plug ignition, compression = self-igniting (Diesel engines)
 
 DTCList:
-  deprecation: v5.0 replaced with Vehicle.Diagnostics.DTCList
   datatype: string[]
   type: sensor
   description: List of currently active DTCs formatted according OBD II (SAE-J2012DA_201812) standard ([P|C|B|U]XXXXX )
 
 FreezeDTC:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: string
   type: sensor
   description: PID 02 - DTC that triggered the freeze frame
 
 FuelStatus:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: string
   type: sensor
   description: PID 03 - Fuel status
 
 EngineLoad:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: percent
   description: PID 04 - Engine load in percent - 0 = no load, 100 = full load
 
 CoolantTemperature:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: celsius
   description: PID 05 - Coolant temperature
 
 ShortTermFuelTrim1:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: percent
   description: PID 06 - Short Term (immediate) Fuel Trim - Bank 1 - negative percent leaner, positive percent richer
 
 LongTermFuelTrim1:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: percent
   description: PID 07 - Long Term (learned) Fuel Trim - Bank 1 - negative percent leaner, positive percent richer
 
 ShortTermFuelTrim2:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: percent
   description: PID 08 - Short Term (immediate) Fuel Trim - Bank 2 - negative percent leaner, positive percent richer
 
 LongTermFuelTrim2:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: percent
   description: PID 09 - Long Term (learned) Fuel Trim - Bank 2 - negative percent leaner, positive percent richer
 
 FuelPressure:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: kPa
@@ -164,55 +127,47 @@ FuelPressure:
 
 MAP:
   datatype: float
-  deprecation: v5.0 OBD-branch is deprecated.
   type: sensor
   unit: kPa
   description: PID 0B - Intake manifold pressure
 
 EngineSpeed:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: rpm
   description: PID 0C - Engine speed measured as rotations per minute
 
 Speed:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: km/h
   description: PID 0D - Vehicle speed
 
 TimingAdvance:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: degrees
   description: PID 0E - Time advance
 
 IntakeTemp:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: celsius
   description: PID 0F - Intake temperature
 
 MAF:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: g/s
   description: PID 10 - Grams of air drawn into engine per second
 
 ThrottlePosition:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: percent
   description: PID 11 - Throttle position - 0 = closed throttle, 100 = open throttle
 
 AirStatus:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: string
   type: sensor
   description: PID 12 - Secondary air status
@@ -224,327 +179,278 @@ AirStatus:
 # Vehicles with more than 2 banks report sensor mapping in PID 1D instead of PID 13
 #
 OxygenSensorsIn2Banks:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: uint8
   type: sensor
   description: PID 13 - Presence of oxygen sensors in 2 banks. [A0..A3] == Bank 1, Sensors 1-4. [A4..A7] == Bank 2, Sensors 1-4
 
 O2:
-  deprecation: v5.0 OBD-branch is deprecated.
   instances:
     - Sensor[1,8]
   type: branch
   description: Oxygen sensors (PID 14 - PID 1B)
 
 O2.Voltage:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: V
   description: PID 1x (byte A) - Sensor voltage
 
 O2.ShortTermFuelTrim:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: percent
   description: PID 1x (byte B) - Short term fuel trim
 
 OBDStandards:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: uint8
   type: attribute
   description: PID 1C - OBD standards this vehicle conforms to
 
 OxygenSensorsIn4Banks:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: uint8
   type: sensor
   description: PID 1D - Presence of oxygen sensors in 4 banks. Similar to PID 13, but [A0..A7] == [B1S1, B1S2, B2S1, B2S2, B3S1, B3S2, B4S1, B4S2]
 
 IsPTOActive:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: boolean
   type: sensor
   description: PID 1E - Auxiliary input status (power take off)
 
 RunTime:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: s
   description: PID 1F - Engine run time
 
 DistanceWithMIL:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: km
   description: PID 21 - Distance traveled with MIL on
 
 FuelRailPressureVac:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: kPa
   description: PID 22 - Fuel rail pressure relative to vacuum
 
 FuelRailPressureDirect:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: kPa
   description: PID 23 - Fuel rail pressure direct inject
 
 O2WR:
-  deprecation: v5.0 OBD-branch is deprecated.
   instances:
     - Sensor[1,8]
   type: branch
   description: Wide range/band oxygen sensors (PID 24 - 2B and PID 34 - 3B)
 
 O2WR.Lambda:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   description: PID 2x (byte AB) and PID 3x (byte AB) - Lambda for wide range/band oxygen sensor
 
 O2WR.Voltage:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: V
   description: PID 2x (byte CD) - Voltage for wide range/band oxygen sensor
 
 O2WR.Current:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: A
   description: PID 3x (byte CD) - Current for wide range/band oxygen sensor
 
 CommandedEGR:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: percent
   description: PID 2C - Commanded exhaust gas recirculation (EGR)
 
 EGRError:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: percent
   description: PID 2D - Exhaust gas recirculation (EGR) error
 
 CommandedEVAP:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: percent
   description: PID 2E - Commanded evaporative purge (EVAP) valve
 
 FuelLevel:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: percent
   description: PID 2F - Fuel level in the fuel tank
 
 WarmupsSinceDTCClear:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: uint8
   type: sensor
   description: PID 30 - Number of warm-ups since codes cleared
 
 DistanceSinceDTCClear:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: km
   description: PID 31 - Distance traveled since codes cleared
 
 EVAPVaporPressure:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: Pa
   description: PID 32 - Evaporative purge (EVAP) system pressure
 
 BarometricPressure:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: kPa
   description: PID 33 - Barometric pressure
 
 Catalyst:
-  deprecation: v5.0 OBD-branch is deprecated.
   type: branch
   description: Catalyst signals
 
 Catalyst.Bank1:
-  deprecation: v5.0 OBD-branch is deprecated.
   type: branch
   description: Catalyst bank 1 signals
 
 Catalyst.Bank1.Temperature1:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: celsius
   description: PID 3C - Catalyst temperature from bank 1, sensor 1
 
 Catalyst.Bank1.Temperature2:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: celsius
   description: PID 3E - Catalyst temperature from bank 1, sensor 2
 
 Catalyst.Bank2:
-  deprecation: v5.0 OBD-branch is deprecated.
   type: branch
   description: Catalyst bank 2 signals
 
 Catalyst.Bank2.Temperature1:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: celsius
   description: PID 3D - Catalyst temperature from bank 2, sensor 1
 
 Catalyst.Bank2.Temperature2:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: celsius
   description: PID 3F - Catalyst temperature from bank 2, sensor 2
 
 DriveCycleStatus:
-  deprecation: v5.0 OBD-branch is deprecated.
   type: branch
   description: PID 41 - OBD status for the current drive cycle
 
 DriveCycleStatus.IsMILOn:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: boolean
   type: sensor
   description: Malfunction Indicator Light (MIL) - False = Off, True = On
 
 DriveCycleStatus.DTCCount:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: uint8
   type: sensor
   description: Number of sensor Trouble Codes (DTC)
 
 DriveCycleStatus.IgnitionType:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: string
   type: sensor
   allowed: ['SPARK', 'COMPRESSION']
   description: Type of the ignition for ICE - spark = spark plug ignition, compression = self-igniting (Diesel engines)
 
 ControlModuleVoltage:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: V
   description: PID 42 - Control module voltage
 
 AbsoluteLoad:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: percent
   description: PID 43 - Absolute load value
 
 CommandedEquivalenceRatio:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: ratio
   description: PID 44 - Commanded equivalence ratio
 
 RelativeThrottlePosition:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: percent
   description: PID 45 - Relative throttle position
 
 AmbientAirTemperature:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: celsius
   description: PID 46 - Ambient air temperature
 
 ThrottlePositionB:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: percent
   description: PID 47 - Absolute throttle position B
 
 ThrottlePositionC:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: percent
   description: PID 48 - Absolute throttle position C
 
 AcceleratorPositionD:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: percent
   description: PID 49 - Accelerator pedal position D
 
 AcceleratorPositionE:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: percent
   description: PID 4A - Accelerator pedal position E
 
 AcceleratorPositionF:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: percent
   description: PID 4B - Accelerator pedal position F
 
 ThrottleActuator:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: percent
   description: PID 4C - Commanded throttle actuator
 
 RunTimeMIL:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: min
   description: PID 4D - Run time with MIL on
 
 TimeSinceDTCCleared:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: min
   description: PID 4E - Time since trouble codes cleared
 
 MaxMAF:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: g/s
   description: PID 50 - Maximum flow for mass air flow sensor
 
 FuelType:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: uint8
   type: attribute
   min: 0
@@ -552,119 +458,102 @@ FuelType:
   description: PID 51 - Fuel type
 
 EthanolPercent:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: percent
   description: PID 52 - Percentage of ethanol in the fuel
 
 EVAPVaporPressureAbsolute:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: kPa
   description: PID 53 - Absolute evaporative purge (EVAP) system pressure
 
 EVAPVaporPressureAlternate:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: Pa
   description: PID 54 - Alternate evaporative purge (EVAP) system pressure
 
 ShortTermO2Trim1:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: percent
   description: PID 55 (byte A) - Short term secondary O2 trim - Bank 1
 
 ShortTermO2Trim3:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: percent
   description: PID 55 (byte B) - Short term secondary O2 trim - Bank 3
 
 LongTermO2Trim1:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: percent
   description: PID 56 (byte A) - Long term secondary O2 trim - Bank 1
 
 LongTermO2Trim3:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: percent
   description: PID 56 (byte B) - Long term secondary O2 trim - Bank 3
 
 ShortTermO2Trim2:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: percent
   description: PID 57 (byte A) - Short term secondary O2 trim - Bank 2
 
 ShortTermO2Trim4:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: percent
   description: PID 57 (byte B) - Short term secondary O2 trim - Bank 4
 
 LongTermO2Trim2:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: percent
   description: PID 58 (byte A) - Long term secondary O2 trim - Bank 2
 
 LongTermO2Trim4:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: percent
   description: PID 58 (byte B) - Long term secondary O2 trim - Bank 4
 
 FuelRailPressureAbsolute:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: kPa
   description: PID 59 - Absolute fuel rail pressure
 
 RelativeAcceleratorPosition:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: percent
   description: PID 5A - Relative accelerator pedal position
 
 HybridBatteryRemaining:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: percent
   description: PID 5B - Remaining life of hybrid battery
 
 OilTemperature:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: celsius
   description: PID 5C - Engine oil temperature
 
 FuelInjectionTiming:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: degrees
   description: PID 5D - Fuel injection timing
 
 FuelRate:
-  deprecation: v5.0 OBD-branch is deprecated.
   datatype: float
   type: sensor
   unit: l/h

--- a/spec/Vehicle/Diagnostics.vspec
+++ b/spec/Vehicle/Diagnostics.vspec
@@ -1,0 +1,21 @@
+# Copyright (c) 2023 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
+Diagnostics:
+  type: branch
+  description: Diagnostics data.
+
+Diagnostics.DTCCount:
+  datatype: uint8
+  type: sensor
+  description: Number of Diagnostic Trouble Codes (DTC)
+
+Diagnostics.DTCList:
+  datatype: string[]
+  type: sensor
+  description: List of currently active DTCs formatted according OBD II (SAE-J2012DA_201812) standard ([P|C|B|U]XXXXX )

--- a/spec/VehicleSignalSpecification.vspec
+++ b/spec/VehicleSignalSpecification.vspec
@@ -184,6 +184,7 @@ Vehicle.Service:
   description: Service data.
 
 #include Vehicle/Service.vspec Vehicle.Service
+
 #
 # Connectivity information
 #
@@ -192,3 +193,5 @@ Vehicle.Connectivity:
   description: Connectivity data.
 
 #include Vehicle/Connectivity.vspec Vehicle.Connectivity
+
+#include Vehicle/Diagnostics.vspec Vehicle


### PR DESCRIPTION
This is a follow up to https://github.com/COVESA/vehicle_signal_specification/issues/635. Intention is to have them deprecated and remove them first in VSS 6.0 Until then anyone can create PRs with replacement signals as needed. This PR contains replacement signals for diagnostics.

As a first point we should we discuss if this is a good approach for removing the OBD branch.
