### PR TITLE
Exclude UUID from release artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,18 @@ A new version of vss-tools is used, with support for static IDs and jsconschema.
 
 ## Planned Changes VSS 5.0
 
+### UUID removed from release artifacts
+
+VSS Release artifacts (VSS standard catalog in various formats) will no longer contain UUID information.
+If you need artifacts with UUID you need to generate the artifact yourself.
+
+Instructions:
+
+1. Clone the repo and check out the tag you want, for example `git checkout v5.0`
+2. Update submodules, for example `git submodule update --init`
+3. Add `--uuid` as argument to the relevant command in `Makefile`
+4. Run generation, for example `make csv`.
+
 ### OBD Branch deprecated
 
 The `Vehicle.OBD` branch is now deprecated. The plan is to remove it in VSS 6.0.

--- a/Makefile
+++ b/Makefile
@@ -21,50 +21,50 @@ optional_targets: clean protobuf ttl
 TOOLSDIR?=./vss-tools
 
 json:
-	${TOOLSDIR}/vspec2json.py -I ./spec --uuid -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).json
+	${TOOLSDIR}/vspec2json.py -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).json
 
 json-noexpand:
-	${TOOLSDIR}/vspec2json.py -I ./spec --uuid -u ./spec/units.yaml --no-expand ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION)_noexpand.json
+	${TOOLSDIR}/vspec2json.py -u ./spec/units.yaml --no-expand ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION)_noexpand.json
 
 jsonschema:
-	${TOOLSDIR}/vspec2jsonschema.py -I ./spec --uuid -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).jsonschema
+	${TOOLSDIR}/vspec2jsonschema.py -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).jsonschema
 
 franca:
-	${TOOLSDIR}/vspec2franca.py --franca-vss-version $$(cat VERSION)  -I ./spec --uuid -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).fidl
+	${TOOLSDIR}/vspec2franca.py --franca-vss-version $$(cat VERSION) -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).fidl
 
 yaml:
-	${TOOLSDIR}/vspec2yaml.py -I ./spec --uuid -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).yaml
+	${TOOLSDIR}/vspec2yaml.py -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).yaml
 
 csv:
-	${TOOLSDIR}/vspec2csv.py -I ./spec --uuid -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).csv
+	${TOOLSDIR}/vspec2csv.py -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).csv
 
 ddsidl:
-	${TOOLSDIR}/vspec2ddsidl.py -I ./spec --uuid -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).idl
+	${TOOLSDIR}/vspec2ddsidl.py -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).idl
 
 # Verifies that supported overlay combinations are syntactically correct.
 overlays:
-	${TOOLSDIR}/vspec2json.py -I ./spec --uuid -u ./spec/units.yaml -o overlays/profiles/motorbike.vspec ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION)_motorbike.json
-	${TOOLSDIR}/vspec2json.py -I ./spec --uuid -u ./spec/units.yaml -o overlays/extensions/dual_wiper_systems.vspec ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION)_dualwiper.json
-	${TOOLSDIR}/vspec2json.py -I ./spec --uuid -u ./spec/units.yaml -o overlays/extensions/OBD.vspec ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION)_obd.json
+	${TOOLSDIR}/vspec2json.py -u ./spec/units.yaml -o overlays/profiles/motorbike.vspec ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION)_motorbike.json
+	${TOOLSDIR}/vspec2json.py -u ./spec/units.yaml -o overlays/extensions/dual_wiper_systems.vspec ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION)_dualwiper.json
+	${TOOLSDIR}/vspec2json.py -u ./spec/units.yaml -o overlays/extensions/OBD.vspec ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION)_obd.json
 
 tests:
 	PYTHONPATH=${TOOLSDIR} pytest
 
 binary:
 	cd ${TOOLSDIR}/binary && $(MAKE)
-	${TOOLSDIR}/vspec2binary.py --uuid -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).binary
+	${TOOLSDIR}/vspec2binary.py -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).binary
 
 protobuf:
-	${TOOLSDIR}/vspec2protobuf.py  -I ./spec -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).proto
+	${TOOLSDIR}/vspec2protobuf.py -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).proto
 
 graphql:
-	${TOOLSDIR}/vspec2graphql.py -I ./spec  -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).graphql.ts
+	${TOOLSDIR}/vspec2graphql.py -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).graphql.ts
 
 ttl:
-	${TOOLSDIR}/contrib/vspec2ttl/vspec2ttl.py -I ./spec -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).ttl
+	${TOOLSDIR}/contrib/vspec2ttl/vspec2ttl.py -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).ttl
 
 id:
-	${TOOLSDIR}/vspec2id.py -I ./spec --uuid -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).vspec
+	${TOOLSDIR}/vspec2id.py -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).vspec
 
 clean:
 	cd ${TOOLSDIR}/binary && $(MAKE) clean


### PR DESCRIPTION
This is a proposal to remove UUIDs from VSS 5.0 release artifacts. Background is that we have not yet heard about anyone actually using them, and if someone need them they can anyway generate them themselves.

Possible discussion points:

- If we agree on that we long term want to remove it, but think 5.0 is too soon then we could instead mention it as a planned change for 6.0
- If we agree on removing it we can discuss if we (long term) want to keep `--uuid` at all, or if we already now at 5.0 (or 6.0) shall mark it as deprecated, i.e. plan to remove it one major release later (i.e. 6.0 or 7.0)