### PR TITLE
Add gitattributes to get better statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.vspec linguist-detectable
+*.vspec linguist-language=YAML
+docs-gen/** linguist-documentation
+Makefile -linguist-detectable


### PR DESCRIPTION
As of today Github statistics show: 

![image](https://github.com/COVESA/vehicle_signal_specification/assets/30996601/b4c6b684-206d-43e3-abd5-70b061fb35d0)

This PR changes so that it reports that this repo consists of 100% YAML. (The [Linguist Framework](https://github.com/github-linguist/linguist/blob/master/docs/overrides.md) does not consider VSS as an "official language", so we cannot yet get it to report VSS as language). As VSS *.vspec files are YAMl files reporting content as 100% YAML makes sense, I think

Result with config file applied:

```
erik@debian4:~/vehicle_signal_specification$ github-linguist
100.00% 158100     YAML
```

