### PR TITLE
Add wheel angular speed

### DIFF
--- a/spec/Chassis/Wheel.vspec
+++ b/spec/Chassis/Wheel.vspec
@@ -66,8 +66,17 @@ Tire.Temperature:
 #
 # Wheel signals
 #
+
 Speed:
   datatype: float
   type: sensor
   unit: km/h
-  description: Rotational speed of a vehicle's wheel.
+  description: Linear speed of a vehicle's wheel.
+
+AngularSpeed:
+  datatype: float
+  type: sensor
+  unit: degrees/s
+  description: Angular (Rotational) speed of a vehicle's wheel.
+  comment: Positive if wheel is trying to drive vehicle forward.
+           Negative if wheel is trying to drive vehicle backward.


### PR DESCRIPTION
Fixes #678
Related to #677 

I suggest that we add a new signal rather than "refactoring" the old, as there might be use-cases where linear speed is useful, like if you have a passive TPMS system (and different wheel sizes) or if you use the average speed of individual wheels) with different size)  to calculate `Vehicle.Speed`

Also changing description of existing signal, but semantics should be the same.
I used `degrees/s` as unit as that is the only unit we currently have for angular velocity.
As I see it it would not be a problem for us to add `rad`and `rad/s` to the list of supported units and use `rad/s` if we prefer that.

While discussing angular/rotation-speed it can also be worth mentioning that as of today we have two different quantities:

- `angular-speed` (supported unit `degrees/s`)
- `rotational-speed` (supported unit `rpm`)

Do we see a need to keep both quantities; cannot `rpm` also be considered as a form of angular speed, and at least for something rotating with constant speed it is easy to convert between `degrees/s` and `rpm`.