### PR TITLE
Enforce strict check in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,52 +19,54 @@ mandatory_targets: clean json json-noexpand franca yaml binary csv graphql ddsid
 optional_targets: clean protobuf ttl
 
 TOOLSDIR?=./vss-tools
+COMMON_ARGS=-u ./spec/units.yaml --strict
 
 json:
-	${TOOLSDIR}/vspec2json.py -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).json
+	${TOOLSDIR}/vspec2json.py ${COMMON_ARGS} ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).json
 
 json-noexpand:
-	${TOOLSDIR}/vspec2json.py -u ./spec/units.yaml --no-expand ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION)_noexpand.json
+	${TOOLSDIR}/vspec2json.py ${COMMON_ARGS} --no-expand ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION)_noexpand.json
 
 jsonschema:
-	${TOOLSDIR}/vspec2jsonschema.py -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).jsonschema
+	${TOOLSDIR}/vspec2jsonschema.py ${COMMON_ARGS} ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).jsonschema
 
 franca:
-	${TOOLSDIR}/vspec2franca.py --franca-vss-version $$(cat VERSION) -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).fidl
+	${TOOLSDIR}/vspec2franca.py --franca-vss-version $$(cat VERSION) ${COMMON_ARGS} ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).fidl
 
 yaml:
-	${TOOLSDIR}/vspec2yaml.py -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).yaml
+	${TOOLSDIR}/vspec2yaml.py ${COMMON_ARGS} ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).yaml
 
 csv:
-	${TOOLSDIR}/vspec2csv.py -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).csv
+	${TOOLSDIR}/vspec2csv.py ${COMMON_ARGS} ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).csv
 
 ddsidl:
-	${TOOLSDIR}/vspec2ddsidl.py -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).idl
+	${TOOLSDIR}/vspec2ddsidl.py ${COMMON_ARGS} ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).idl
 
 # Verifies that supported overlay combinations are syntactically correct.
 overlays:
-	${TOOLSDIR}/vspec2json.py -u ./spec/units.yaml -o overlays/profiles/motorbike.vspec ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION)_motorbike.json
-	${TOOLSDIR}/vspec2json.py -u ./spec/units.yaml -o overlays/extensions/dual_wiper_systems.vspec ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION)_dualwiper.json
-	${TOOLSDIR}/vspec2json.py -u ./spec/units.yaml -o overlays/extensions/OBD.vspec ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION)_obd.json
+	${TOOLSDIR}/vspec2json.py ${COMMON_ARGS} -o overlays/profiles/motorbike.vspec ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION)_motorbike.json
+	${TOOLSDIR}/vspec2json.py ${COMMON_ARGS} -o overlays/extensions/dual_wiper_systems.vspec ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION)_dualwiper.json
+	${TOOLSDIR}/vspec2json.py ${COMMON_ARGS} -o overlays/extensions/OBD.vspec ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION)_obd.json
 
 tests:
 	PYTHONPATH=${TOOLSDIR} pytest
 
 binary:
 	cd ${TOOLSDIR}/binary && $(MAKE)
-	${TOOLSDIR}/vspec2binary.py -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).binary
+	${TOOLSDIR}/vspec2binary.py ${COMMON_ARGS} ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).binary
 
 protobuf:
-	${TOOLSDIR}/vspec2protobuf.py -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).proto
+	${TOOLSDIR}/vspec2protobuf.py ${COMMON_ARGS} ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).proto
 
 graphql:
-	${TOOLSDIR}/vspec2graphql.py -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).graphql.ts
+	${TOOLSDIR}/vspec2graphql.py ${COMMON_ARGS} ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).graphql.ts
 
+# vspec2ttl does not use common generator framework
 ttl:
 	${TOOLSDIR}/contrib/vspec2ttl/vspec2ttl.py -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).ttl
 
 id:
-	${TOOLSDIR}/vspec2id.py -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).vspec
+	${TOOLSDIR}/vspec2id.py ${COMMON_ARGS} ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).vspec
 
 clean:
 	cd ${TOOLSDIR}/binary && $(MAKE) clean


### PR DESCRIPTION
This means that CI checks will fail if a signal name does not fulfill the rules for being included in VSS standard catalog 