### PR TITLE
Add screen mirroring in Infotainment.vspec

### DIFF
--- a/spec/Cabin/Infotainment.vspec
+++ b/spec/Cabin/Infotainment.vspec
@@ -267,4 +267,27 @@ SmartphoneProjection.SupportedMode:
   allowed: [ 'ANDROID_AUTO', 'APPLE_CARPLAY', 'MIRROR_LINK', 'OTHER' ]
   description: Supportable list for projection.
 
+SmartphoneScreenMirroring:
+  type: branch
+  description: All smartphone mirroring actions.
+
+SmartphoneScreenMirroring.Active:
+  datatype: string
+  type: actuator
+  allowed: [ 'NONE', 'ACTIVE', 'INACTIVE' ]
+  description: Mirroring activation info.
+  comment: NONE indicates that mirroring is not supported.
+
+SmartphoneScreenMirroring.Source:
+  datatype: string
+  type: actuator
+  allowed: ['USB', 'BLUETOOTH', 'WIFI']
+  description: Connectivity source selected for mirroring.
+
+SmartphoneScreenMirroring.Resolution:
+  datatype: string
+  type: attribute
+  allowed: ['RES_720P', 'RES_1080P', 'RES_4K']
+  description: Display resolution for the mirrored content.
+
 #include include/PowerOptimize.vspec

--- a/spec/Cabin/Infotainment.vspec
+++ b/spec/Cabin/Infotainment.vspec
@@ -270,8 +270,7 @@ SmartphoneProjection.SupportedMode:
 
 SmartphoneScreenMirroring:
   type: branch
-  description: All smartphone screen mirroring actions.
-  comment: Smartphone screen mirroring mirrors the whole screen of the Smartphone on the vehicle infotainment system.
+  description: All smartphone mirroring actions.
 
 SmartphoneScreenMirroring.Active:
   datatype: string

--- a/spec/Cabin/Infotainment.vspec
+++ b/spec/Cabin/Infotainment.vspec
@@ -247,7 +247,6 @@ HMI.DisplayOffDuration:
 SmartphoneProjection:
   type: branch
   description: All smartphone projection actions.
-  comment: Smartphone projection exposes or controls specific applications on the Smartphone on the vehicle infotainment system.
 
 SmartphoneProjection.Active:
   datatype: string
@@ -261,6 +260,7 @@ SmartphoneProjection.Source:
   type: actuator
   allowed: ['USB', 'BLUETOOTH', 'WIFI']
   description: Connectivity source selected for projection.
+  comment: Smartphone projection exposes or controls specific applications on the Smartphone on the vehicle infotainment system.
 
 SmartphoneProjection.SupportedMode:
   datatype: string[]

--- a/spec/Cabin/Infotainment.vspec
+++ b/spec/Cabin/Infotainment.vspec
@@ -247,6 +247,7 @@ HMI.DisplayOffDuration:
 SmartphoneProjection:
   type: branch
   description: All smartphone projection actions.
+  comment: Smartphone projection exposes or controls specific applications on the Smartphone on the vehicle infotainment system.
 
 SmartphoneProjection.Active:
   datatype: string
@@ -270,7 +271,8 @@ SmartphoneProjection.SupportedMode:
 
 SmartphoneScreenMirroring:
   type: branch
-  description: All smartphone mirroring actions.
+  description: All smartphone screen mirroring actions.
+  comment: Smartphone screen mirroring mirrors the whole screen of the Smartphone on the vehicle infotainment system.
 
 SmartphoneScreenMirroring.Active:
   datatype: string

--- a/spec/Cabin/Infotainment.vspec
+++ b/spec/Cabin/Infotainment.vspec
@@ -286,7 +286,7 @@ SmartphoneScreenMirroring.Source:
 
 SmartphoneScreenMirroring.Resolution:
   datatype: string
-  type: attribute
+  type: sensor
   allowed: ['RES_720P', 'RES_1080P', 'RES_4K']
   description: Display resolution for the mirrored content.
 

--- a/spec/Cabin/Infotainment.vspec
+++ b/spec/Cabin/Infotainment.vspec
@@ -247,6 +247,7 @@ HMI.DisplayOffDuration:
 SmartphoneProjection:
   type: branch
   description: All smartphone projection actions.
+  comment: Smartphone projection exposes or controls specific applications on the Smartphone on the vehicle infotainment system.
 
 SmartphoneProjection.Active:
   datatype: string
@@ -269,7 +270,8 @@ SmartphoneProjection.SupportedMode:
 
 SmartphoneScreenMirroring:
   type: branch
-  description: All smartphone mirroring actions.
+  description: All smartphone screen mirroring actions.
+  comment: Smartphone screen mirroring mirrors the whole screen of the Smartphone on the vehicle infotainment system.
 
 SmartphoneScreenMirroring.Active:
   datatype: string

--- a/spec/Cabin/Infotainment.vspec
+++ b/spec/Cabin/Infotainment.vspec
@@ -287,10 +287,4 @@ SmartphoneScreenMirroring.Source:
   allowed: ['USB', 'BLUETOOTH', 'WIFI']
   description: Connectivity source selected for mirroring.
 
-SmartphoneScreenMirroring.Resolution:
-  datatype: string
-  type: sensor
-  allowed: ['RES_720P', 'RES_1080P', 'RES_4K']
-  description: Display resolution for the mirrored content.
-
 #include include/PowerOptimize.vspec


### PR DESCRIPTION
This PR is rework of PR #699 .
The type of SmartphoneScreenMirroring.Resolution is changed to 'sensor'.

The differences of smartphone screen mirroring with smartphone projection as follow:
Screen Mirroring, such as through AirPlay, mirrors all activities of a device’s screen, allowing every detail to be displayed on a secondary screen. On the other hand, existing Projection specifically targets in-vehicle use, selectively providing access to certain applications in smartphone like navigation and music players.
Specifically, Screen Mirroring enables the casting of applications not typically offered by Projection, such as 'YouTube', to a vehicle's display. Therefore, Screen Mirroring and Projection are parallel technologies, each serving distinct use cases without overlapping functionalities.