### PR TITLE
Add rad/s

### DIFF
--- a/spec/units.yaml
+++ b/spec/units.yaml
@@ -96,6 +96,12 @@ degrees/s:
   unit: degree per second
   quantity: angular-speed
   allowed-datatypes: ['numeric']
+rad/s:
+  definition: Angular speed measured in radians per second
+  unit: radians per second
+  quantity: angular-speed
+  allowed-datatypes: ['numeric']
+
 
 # Power
 


### PR DESCRIPTION
COVESA VSS Standard Catalog already supports deg/s for angular speed, but in some areas rad/s is commonly used. This PR adds rad/s, so that it can be used both in the standard catalog as well as in user extensions.