### PR TITLE
adding AdaptiveDistance AdaptiveTimeGap for insurance needs in CV activity

### DIFF
--- a/spec/ADAS/ADAS.vspec
+++ b/spec/ADAS/ADAS.vspec
@@ -86,6 +86,16 @@ CruiseControl.IsError:
   type: sensor
   description: Indicates if cruise control system incurred an error condition. True = Error. False = No Error.
 
+CruiseControl.AdaptiveDistance:
+  datatype: float
+  type: actuator
+  description: Distance in meters of forward detected object 
+
+CruiseControl.AdaptiveTimeGap:
+  datatype: float
+  type: actuator
+  description: Time in seconds before potential impact to forward object
+
 #
 # Lane Departure Detection System
 #


### PR DESCRIPTION
Drawing from Android Automotive documentation

https://source.android.com/docs/automotive/vhal/adas-properties

which has:

ADAPTIVE_CRUISE_CONTROL_TARGET_TIME_GAP
ADAPTIVE_CRUISE_CONTROL_LEAD_VEHICLE_DISTANCE

we came up with the equivalent for VSS. Similar would logically exist for Emergency Braking Assist (EBA) which presumably uses the same sensor (lidar, camera or radar. While the time gap can be calculated based on distance and vehicle speed, we feel it should be a primary signal.