### PR TITLE
adding ObstacleDetection and Adaptive Cruise control signals

### DIFF
--- a/spec/ADAS/ADAS.vspec
+++ b/spec/ADAS/ADAS.vspec
@@ -86,7 +86,7 @@ CruiseControl.IsError:
   type: sensor
   description: Indicates if cruise control system incurred an error condition. True = Error. False = No Error.
 
-CruiseControl.AdaptiveIsActive:
+CruiseControl.isAdaptiveActive:
   datatype: boolean
   type: actuator
   description: Indicates if adaptive cruise control system is active (i.e. actively controls speed).

--- a/spec/ADAS/ADAS.vspec
+++ b/spec/ADAS/ADAS.vspec
@@ -86,6 +86,18 @@ CruiseControl.IsError:
   type: sensor
   description: Indicates if cruise control system incurred an error condition. True = Error. False = No Error.
 
+CruiseControl.AdaptiveIsActive:
+  datatype: boolean
+  type: actuator
+  description: Indicates if adaptive cruise control system is active (i.e. actively controls speed).
+               True = Active. False = Inactive.
+
+CruiseControl.AdaptiveDistanceSet:
+  datatype: float
+  type: actuator
+  unit: m
+  description: Distance in meters to keep from lead vehicle
+
 #
 # Lane Departure Detection System
 #
@@ -130,6 +142,18 @@ ObstacleDetection.IsError:
   datatype: boolean
   type: sensor
   description: Indicates if obstacle sensor system incurred an error condition. True = Error. False = No Error.
+
+ObstacleDetection:ForwardDistance:
+  datatype: float
+  type: sensor
+  unit: m
+  description: Distance in meters to forward detected object
+
+ObstacleDetection:ForwardTimeGap:
+  datatype: int32
+  type: sensor
+  unit: ms
+  description: Time in milliseconds before potential impact to forward object
 
 
 #

--- a/spec/ADAS/ADAS.vspec
+++ b/spec/ADAS/ADAS.vspec
@@ -86,7 +86,7 @@ CruiseControl.IsError:
   type: sensor
   description: Indicates if cruise control system incurred an error condition. True = Error. False = No Error.
 
-CruiseControl.isAdaptiveActive:
+CruiseControl.IsAdaptiveActive:
   datatype: boolean
   type: actuator
   description: Indicates if adaptive cruise control system is active (i.e. actively controls speed).

--- a/spec/ADAS/ADAS.vspec
+++ b/spec/ADAS/ADAS.vspec
@@ -143,13 +143,13 @@ ObstacleDetection.IsError:
   type: sensor
   description: Indicates if obstacle sensor system incurred an error condition. True = Error. False = No Error.
 
-ObstacleDetection:ForwardDistance:
+ObstacleDetection.ForwardDistance:
   datatype: float
   type: sensor
   unit: m
   description: Distance in meters to forward detected object
 
-ObstacleDetection:ForwardTimeGap:
+ObstacleDetection.ForwardTimeGap:
   datatype: int32
   type: sensor
   unit: ms


### PR DESCRIPTION
adding ObstacleDetection:ForwardDistance ObstacleDetection:ForwardTimeGap CruiseControl.AdaptiveIsActive CruiseControl.AdaptiveDistanceSet

Drawing from Android Automotive documentation

https://source.android.com/docs/automotive/vhal/adas-properties

which has:

ADAPTIVE_CRUISE_CONTROL_TARGET_TIME_GAP
ADAPTIVE_CRUISE_CONTROL_LEAD_VEHICLE_DISTANCE

The Commercial Vehicle group came up with the proposed PR for VSS. Cruise Control and Emergency Braking Assist may share the sensor data if vehicle has both so we felt it appropriate to place some of this under ObjectDetection. While the time gap can be calculated based on distance and vehicle speed, we feel it should be defined and represented in VSS.

Nearby we also want to include blind spot detection, both left and right. Vehicle SAE ActiveAutonomyLevel less than 2 tend to merely indicate presence of a vehicle in blind spot, surely level 3 and greater keep track of distance. Instead of staging a proposed representation for left and right isWarning booleans and possibly distance, want to discuss on VSS call what a better future proof representation may be. There may be object (obstacle) presence and distance detection for multiple directions.  
