### PR TITLE
ObstacleDetection instances, attributes and Adaptive CruiseControl

### DIFF
--- a/spec/ADAS/ADAS.vspec
+++ b/spec/ADAS/ADAS.vspec
@@ -86,6 +86,17 @@ CruiseControl.IsError:
   type: sensor
   description: Indicates if cruise control system incurred an error condition. True = Error. False = No Error.
 
+CruiseControl.IsAdaptive:
+  datatype: boolean
+  type: actuator
+  description: Indicates if cruise control system is adaptive (i.e. actively controls speed).
+
+CruiseControl.AdaptiveDistanceSet:
+  datatype: float
+  type: actuator
+  unit: m
+  description: Distance in meters to keep from lead vehicle
+  
 #
 # Lane Departure Detection System
 #
@@ -113,6 +124,9 @@ LaneDepartureDetection.IsError:
 #
 ObstacleDetection:
   type: branch
+  instances:
+    - ["Front", "Rear"]
+    - ["Left", "Center", "Right"]
   description: Signals form Obstacle Sensor System.
 
 ObstacleDetection.IsEnabled:
@@ -131,6 +145,28 @@ ObstacleDetection.IsError:
   type: sensor
   description: Indicates if obstacle sensor system incurred an error condition. True = Error. False = No Error.
 
+ObstacleDetection.Distance:
+  datatype: float
+  type: sensor
+  unit: m
+  description: Distance in meters to detected object
+
+ObstacleDetection.TimeGap:
+  datatype: int32
+  type: sensor
+  unit: ms
+  description: Time in milliseconds before potential impact object
+
+ObstacleDetection.WarningType:
+  datatype: string
+  type: sensor  
+  allowed: [
+    'UNDEFINED',      # Object detection warning not further categorized
+    'CROSS_TRAFFIC',  # Detected object is on an indirect trajectory that may intersect
+    'BLIND_SPOT',     # Detected object may not be in driver line of sight, including from mirrors
+    ]
+  description: Indicates the type of obstacle warning detected as some track not only the presence of an obstacle but potential intercepting trajectory or other characteristics.
+  comment: Undefined obstacle warning type would merely alert of presence of obstacle and may measure distance.
 
 #
 # Antilock Braking System


### PR DESCRIPTION
Adaptive cruise control distance setting typically seen on the dashboard user interface as increments (eg 1-5) that may be either vehicle lengths or an incremental variable that also factors in vehicle speed for safe following distance. If the latter a setting of 1 may be 10 meters at 30km/h but 30 at 90 km/h. In that case it would be more important to note the user preferred an adaptive buffer of 1 that has no fixed length but fluctuates with speed. We ask the OEM and suppliers on the VSS call to give clarity to conventions in production wrt adaptive cruise control.

In adding instances to ObstacleDetected, we want to be able to support multiple leaf nodes as multiple obstacles can be detected concurrently. Here too we want input from OEM and suppliers on the multitude of obstacle detecting sensors in mainstream vehicles. We realize more advanced autonomous vehicles will have far more lidar/camera/other sensors detecting and tracking obstacles. Degrees with zero being directly in front would provide more flexibility but trying to keep it simple. We want to avoid Center in both Y and X axis and based on feedback will likely go with "Middle" or "-" for Y.

  instances:
    - ["Front", "-", "Rear"]
    - ["Left", "Center", "Right"]
 
We also want ObjectType such as wildlife, pedestrian, bicycle, vehicle, etc but again hope someone in the community can direct us to an effort like Sensoris that should be leveraged instead of defining ourselves.