### PR TITLE
Separate doc-gen from general build

### DIFF
--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -21,8 +21,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
 
       - name: Install vss-tools dependencies
         run: |
@@ -78,23 +76,3 @@ jobs:
       - name: Test optional targets. NOTE - always succeeds
         run: |
           make -k optional_targets || true
-
-      - name: Install hugo
-        env:
-          HUGO_VER : 0.129.0
-        run: |
-          curl -LO https://github.com/gohugoio/hugo/releases/download/v${HUGO_VER}/hugo_${HUGO_VER}_linux-amd64.deb
-          sudo dpkg -i hugo_${HUGO_VER}_linux-amd64.deb
-
-      - name: Make docs
-        run: |
-          hugo -s ./docs-gen
-
-      - name: Deploy docs
-        # Only deploy docs if this was a push to master
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          branch: gh-pages # The branch the action should deploy to.
-          folder: docs # The folder the action should deploy.
-          commit-message: Auto-deploy docs built from commit ${{ github.sha }}

--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -1,0 +1,37 @@
+name: Documentation Generation
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  docgen:
+    name: Generate and Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Install hugo
+        env:
+          HUGO_VER : 0.129.0
+        run: |
+          curl -LO https://github.com/gohugoio/hugo/releases/download/v${HUGO_VER}/hugo_${HUGO_VER}_linux-amd64.deb
+          sudo dpkg -i hugo_${HUGO_VER}_linux-amd64.deb
+
+      - name: Make docs
+        run: |
+          hugo -s ./docs-gen
+
+      - name: Deploy docs
+        # Only deploy docs if this was a push to master
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: docs # The folder the action should deploy.
+          commit-message: Auto-deploy docs built from commit ${{ github.sha }}


### PR DESCRIPTION
If working on a fork you maybe do not want (or cannot) publish documentation. By putting that in a separate workflow it is easy to disable or remove that workflow.