### PR TITLE
Add RegExp pattern for VehicleIdentification.VIN property.

### DIFF
--- a/spec/Vehicle/Vehicle.vspec
+++ b/spec/Vehicle/Vehicle.vspec
@@ -55,6 +55,7 @@ VehicleIdentification.VIN:
   datatype: string
   type: attribute
   description: 17-character Vehicle Identification Number (VIN) as defined by ISO 3779.
+  pattern: ^([0-9A-HJ-NPR-Z]{3})([0-9A-HJ-NPR-Z]{6})([0-9A-HJ-NPR-Z]{4}[0-9]{4})$
 
 VehicleIdentification.WMI:
   datatype: string


### PR DESCRIPTION
Add Regular Expression pattern for the VehicleIdentification.VIN property.

This PR is dependent on [COVESA VSS-Tools PR: 426](https://github.com/COVESA/vss-tools/pull/426)

The idea is to provide a Regular Expression validation for the which is compliant with the mentioned in the property **description** - [ISO 3779](https://cdn.standards.iteh.ai/samples/52200/7d8a69aee84c4ad28231053f49f4966e/ISO-3779-2009.pdf).

Provided RegExp - pattern is tested on: https://regex101.com/, with a test string of: 1CPH423GAP71E2745 and validates VIN strings as per quoted [ISO 3779](https://cdn.standards.iteh.ai/samples/52200/7d8a69aee84c4ad28231053f49f4966e/ISO-3779-2009.pdf) on below rules:

    1. VIN length of 17 chars where:
    1.1 First 3 characters are for the VMI: 1CP
    1.2 Next 6 characters are for the VDS: H423GA
    1.3 Last 8 characters are for the VIS: P71E2745
    2. The last 4 characters of the VIS part should always be numbers
    3. Letters: I, O and Q shall not be used

**NOTE:** This update should be delivered AFTER the above mentioned  [COVESA VSS-Tools PR: 426](https://github.com/COVESA/vss-tools/pull/426) gets approved and released. Otherwise it will raise the following ERROR / WARNING:

```
WARNING: Unknown extra attribute: 'Vehicle.VehicleIdentification.VIN':'pattern'
``` 
