### PR TITLE
Fix 24.04 build by pinning Python version

### DIFF
--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -14,6 +14,11 @@ on:
         required: false
         type: string
 
+
+env:
+  PYTHON_VERSION: "3.10.6" # keep in sync with vss-tools
+                           # Note: Currently cyclonedds does not support 3.11
+
 jobs:
   buildtest:
     name: Build Test
@@ -21,6 +26,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install vss-tools dependencies
         run: |


### PR DESCRIPTION
GitHub has started to roll-out `ubuntu-24.04`  for `ubuntu-latest`, using Python 3.11 as default, see https://github.com/actions/runner-images/issues/10636 That gives problems for our cyclonedds check as cyclonedds does not support Python 3.11, see https://github.com/eclipse-cyclonedds/cyclonedds-python/issues/221

There are multiple potential ways to solve this:

- Build cyclonedds from scratch
- Skip the cyclonedds tests, we do not change the generation that often so it has limited value
- Use a Python version that is supported.

In this PR I select the last alternative and use the same Python version as we already use in vss-tools, i.e. 3.10.6.