### PR TITLE
PR821 alternative solution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ String types can now be restricted by a RegExp pattern.
 Previously the documentation stated that default values could not be given for struct types.
 That is now supported.
 
+### Signal Updates
+
+* Signals for seats refacored (backward incompatible change)
+
 ## VSS 5.0
 
 ### Signal Updates

--- a/spec/Cabin/Seat.vspec
+++ b/spec/Cabin/Seat.vspec
@@ -23,10 +23,11 @@
 # z-axis is the axis going up/down on the vehicle
 #
 
-IsOccupied:
-  datatype: boolean
+OccupancyStatus:
+  datatype: string
   type: sensor
-  description: Does the seat have a passenger in it.
+  allowed: ['UNKNOWN', 'OCCUPIED', 'EMPTY']
+  description: Occupancy status of the seat.
 
 Occupant:
   deprecation: v5.0 - use data from Vehicle.Occupant.
@@ -54,21 +55,10 @@ SeatBeltHeight:
 #include include/ItemHeatingCooling.vspec
 
 Massage:
-  datatype: uint8
-  type: actuator
-  min: 0
-  max: 100
-  unit: percent
-  description: Seat massage level. 0 = off. 100 = max massage.
-  deprecation: v5.0 - refactored to Seat.MassageLevel
+  type: branch
+  description: Massage related information for the seat.
 
-MassageLevel:
-  datatype: uint8
-  type: actuator
-  min: 0
-  max: 100
-  unit: percent
-  description: Seat massage level. 0 = off. 100 = max massage.
+#include Seat/Massage.vspec Massage
 
 Position:
   datatype: uint16
@@ -77,6 +67,7 @@ Position:
   unit: mm
   description: Seat position on vehicle x-axis. Position is relative to the frontmost position supported by the seat.
                0 = Frontmost position supported.
+
 
 Height:
   datatype: uint16
@@ -101,6 +92,8 @@ Backrest:
   type: branch
   description: Describes signals related to the backrest of the seat.
 
+#include include/ItemHeatingCooling.vspec Backrest
+
 Backrest.Recline:
   datatype: float
   type: actuator
@@ -111,6 +104,8 @@ Backrest.Recline:
   comment:     Seat z-axis depends on seat tilt. This means that movement of backrest due to seat tilting will not
                affect Backrest.Recline as long as the angle between Seating and Backrest are constant.
                Absolute recline relative to vehicle z-axis can be calculated as Tilt + Backrest.Recline.
+
+
 
 Backrest.Lumbar:
   type: branch
@@ -133,6 +128,31 @@ Backrest.LumbarSupport:
   min: 0
   max: 100
   description: Lumbar support (in/out position). 0 = Innermost position. 100 = Outermost position.
+  comment: A vehicle should typically either use this generic lumbar signal or the more specified top/mid/bottom signals.
+
+Backrest.TopLumbarSupport:
+  datatype: float
+  type: actuator
+  unit: percent
+  min: 0
+  max: 100
+  description: Top lumbar support (in/out position). 0 = Innermost position. 100 = Outermost position.
+
+Backrest.MidLumbarSupport:
+  datatype: float
+  type: actuator
+  unit: percent
+  min: 0
+  max: 100
+  description: Mid lumbar support (in/out position). 0 = Innermost position. 100 = Outermost position.
+
+Backrest.BottomLumbarSupport:
+  datatype: float
+  type: actuator
+  unit: percent
+  min: 0
+  max: 100
+  description: Bottom lumbar bsupport (in/out position). 0 = Innermost position. 100 = Outermost position.
 
 Backrest.Lumbar.Height:
   datatype: uint8
@@ -175,11 +195,40 @@ Backrest.SideBolsterSupport:
   description: Side bolster support. 0 = Minimum support (widest side bolster setting).
                100 = Maximum support.
 
+Backrest.SideBolsterSupportLeft:
+  datatype: float
+  type: actuator
+  unit: percent
+  min: 0
+  max: 100
+  description: Side bolster support left. 0 = Minimum support (widest side bolster setting).
+               100 = Maximum support.
+
+Backrest.SideBolsterSupportRight:
+  datatype: float
+  type: actuator
+  unit: percent
+  min: 0
+  max: 100
+  description: Side bolster support right. 0 = Minimum support (widest side bolster setting).
+               100 = Maximum support.
+
+Backrest.UpperShoulderSupport:
+  datatype: float
+  type: actuator
+  unit: percent
+  min: 0
+  max: 100
+  description: Upper shoulder support. 0 = Minimum support (widest side bolster setting).
+               100 = Maximum support.
+
 Seating:
   type: branch
   description: Describes signals related to the seat bottom of the seat.
   comment: Seating is here considered as the part of the seat that supports the thighs.
            Additional cushions (if any) for support of lower legs is not covered by this branch.
+
+#include include/ItemHeatingCooling.vspec Seating
 
 Seating.Length:
   datatype: uint16
@@ -188,6 +237,24 @@ Seating.Length:
   unit: mm
   description: Length adjustment of seating. 0 = Adjustable part of seating in rearmost position
                (Shortest length of seating).
+
+Seating.SideBolsterSupportRight:
+  datatype: float
+  type: actuator
+  unit: percent
+  min: 0
+  max: 100
+  description: Seat bottom side bolster support right. 0 = Minimum support (widest side bolster setting).
+               100 = Maximum support.
+
+Seating.SideBolsterSupportLeft:
+  datatype: float
+  type: actuator
+  unit: percent
+  min: 0
+  max: 100
+  description: Seat bottom side bolster support left. 0 = Minimum support (widest side bolster setting).
+               100 = Maximum support.
 
 Headrest:
   type: branch
@@ -211,10 +278,23 @@ Airbag:
   type: branch
   description: Airbag signals.
 
+Airbag.IsEnabled:
+  datatype: boolean
+  type: sensor
+  description: Airbag enabled status. True = Airbag enabled. False = Airbag not enabled.
+
 Airbag.IsDeployed:
   datatype: boolean
   type: sensor
   description: Airbag deployment status. True = Airbag deployed. False = Airbag not deployed.
+
+NeckScarf:
+  type: branch
+  description: NeckScarf settings.
+
+#include include/ItemHeatingCooling.vspec NeckScarf
+
+#include include/ItemFanSpeed.vspec NeckScarf
 
 
 #---------------------- SWITCHES ----------------------

--- a/spec/Cabin/Seat/Massage.vspec
+++ b/spec/Cabin/Seat/Massage.vspec
@@ -1,0 +1,39 @@
+# Copyright (c) 2025 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
+
+IsAvailable:
+  datatype: boolean
+  type: attribute
+  description: True if the seat have the massage capability
+
+Level:
+  datatype: uint8
+  type: actuator
+  min: 0
+  max: 100
+  unit: percent
+  description: Seat massage level. 0 = off. 100 = max massage.
+
+Status:
+  datatype: string
+  type: sensor
+  allowed: ['ON', 'OFF']
+  description: Massage status.
+
+SupportedTypes:
+  datatype: string[]
+  type: attribute
+  description:  Type of massage.
+  comment: OEMs may define a list of identifiers for supported massage types using the allowed keyword
+
+TypeActive:
+  datatype: string
+  type: actuator
+  description: Type of massage active.
+  comment: OEMs may define a list of identifiers for supported massage types using the allowed keyword

--- a/spec/include/ItemFanSpeed.vspec
+++ b/spec/include/ItemFanSpeed.vspec
@@ -1,0 +1,15 @@
+# Copyright (c) 2025 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
+FanSpeed:
+  type: actuator
+  datatype: uint8
+  min: 0
+  max: 100
+  unit: percent
+  description: Speed of the fan.


### PR DESCRIPTION
This is a partially reworked version of #821 -for discussion.

It incorporate the idea of having a SeatMassage Branch where the following signals are put.

```
vss.csv:1123:Vehicle.Cabin.Seat.Row2.PassengerSide.SeatMassage,branch,,,,,,Massage related information for the seat.,,,
vss.csv:1124:Vehicle.Cabin.Seat.Row2.PassengerSide.SeatMassage.IsAvailable,attribute,boolean,,,,,True if the seat have the massage capability,,,
vss.csv:1125:Vehicle.Cabin.Seat.Row2.PassengerSide.SeatMassage.Level,actuator,uint8,,percent,0,100,Seat massage level. 0 = off. 100 = max massage.,,,
vss.csv:1126:Vehicle.Cabin.Seat.Row2.PassengerSide.SeatMassage.Status,sensor,string,,,,,Massage status.,,"['ON', 'OFF']",
vss.csv:1127:Vehicle.Cabin.Seat.Row2.PassengerSide.SeatMassage.SupportedTypes,attribute,string[],,,,,Type of massage.,OEMs may define a list of identifiers for supported massage types using the allowed keyword,,
vss.csv:1128:Vehicle.Cabin.Seat.Row2.PassengerSide.SeatMassage.TypeActive,actuator,string,,,,,Type of massage active.,OEMs may define a list of identifiers for supported massage types using the allowed keyword,,
```

I have also just renamed/removed old signals which makes sense if we think should this should go to the next major only. So as of now this is a backward incompatible change, but we could handle it as backward compatible as well but does not help much if the next planned release after 5.1 anyway will be 6.0 where we will remove deprecated stuff.

I have merged all changes/commits from Paul