### PR TITLE
Extend tire temperature signals

### DIFF
--- a/spec/Chassis/Wheel.vspec
+++ b/spec/Chassis/Wheel.vspec
@@ -50,7 +50,6 @@ Tire.Pressure:
   type: sensor
   unit: kPa
   description: Tire pressure in kilo-Pascal.
-
 Tire.IsPressureLow:
   datatype: boolean
   type: sensor
@@ -61,7 +60,19 @@ Tire.Temperature:
   type: sensor
   unit: celsius
   description: Tire temperature in Celsius.
+  deprecation: v6.0 - use RubberTemperature or AirTemperature instead.
 
+Tire.RubberTemperature:
+  datatype: float
+  type: sensor
+  unit: celsius
+  description: Rubber temperature of the tire in Celsius.
+
+Tire.AirTemperature:
+  datatype: float
+  type: sensor
+  unit: celsius
+  description: Air temperature inside the tire in Celsius.
 
 #
 # Wheel signals


### PR DESCRIPTION
At the VSS meeting this week we said that it could be an idea to assist @JMorceaux  with a possible PR for the proposed changes, to show a possible implementation.

In this PR I propose to create two new signals and deprecate the old one. Deprecated signals might be removed in major releases but we can keep them longer if we see that as relevant. That would give users time to change to the new signals.

If I am thinking if `Tire.RubberTemperature` might be a better name than `Tire.TireTemperature` as the latter name might be somewhat ambiguous even if the description states that it concern rubber temperature, but I am open to use  `Tire.TireTemperature` if that is preferred


Fixes #836