### PR TITLE
changes unit of Battery Capacities from kWh to Ah TractionBattery.vspec

### DIFF
--- a/spec/Powertrain/TractionBattery.vspec
+++ b/spec/Powertrain/TractionBattery.vspec
@@ -110,13 +110,13 @@ CellVoltage.CellVoltages:
 GrossCapacity:
   datatype: uint16
   type: attribute
-  unit: kWh
+  unit: Ah
   description: Gross capacity of the battery.
 
 NetCapacity:
   datatype: uint16
   type: sensor
-  unit: kWh
+  unit: Ah
   description: Total net capacity of the battery considering aging.
 
 StateOfHealth:


### PR DESCRIPTION
# About
hWh is not a Battery Capacity. Since Batteries can have different Voltages kWh is not a good unit. 
kWh tells somethin about Power which is P = U * I .

## Use Case
We want to use NetCapacity to fulfill EU Battery Pass regulations. Unit of Ah is expected for remaining Capacity. 

Signed-off-by: David Matzek<david.dm.matzek@bmw.de>