### PR TITLE
Add MotionManagement SteerAngle signals

### DIFF
--- a/docs-gen/content/catalog/vehicle_motion_management.md
+++ b/docs-gen/content/catalog/vehicle_motion_management.md
@@ -100,6 +100,7 @@ A rotational speed request (e.g., 1000rpm) is realized by the eAxle. This mode i
 The defined steering signals are the main signals for interacting between vehicle motion features and the steering system on the front axle and are widely used in automotive industry.
 These signals are specified in a generic way to support various steering systems like electric power steering as well as Steer-by-Wire. Therefore, not all signals must necessarily be available/applicable.
 The signal specification supports requests on steering wheel (torque and angle) and the steering rack position which is linked to the steered wheels of the vehicle.
+As an alternative to steering rack position it is possible to use steer angle (single track model).
 The signal requests are further divided in "offset" and "target" signals, where an offset value is used additive to the functionality of the steering system and a "target" value is used as absolute external set-point for steering actuation.
 The different requests are controlled by dedicated "mode" signals for enabling and disabling the steering requests.
 

--- a/spec/Vehicle/MotionManagement/Steering/Axle.vspec
+++ b/spec/Vehicle/MotionManagement/Steering/Axle.vspec
@@ -16,19 +16,27 @@
 
 # See vehicle_motion_management.md for more info
 
-RackPositionOffsetTarget:
-  datatype: int16
-  type: actuator
-  unit: mm
-  description: Rack position offset request to the axle steering actuator (for steer-by-wire),
-               added to the actuator internal calculated set-point.
-               Positive values without internal calculated set point change lead to a left movement of the vehicle (based on ISO8855).
+#########################################################################################
+# General settings, used regardless of whether the vehicle use RackPosition or SteerAngle
+#########################################################################################
 
-RackPositionOffsetTargetMode:
+PositionTargetMode:
   datatype: uint8
   type: actuator
-  description: Mode used for controlling rack position offset interface of axle steering actuator.
+  description: Mode used for controlling position interface of axle steering actuator.
                0 indicates interface disabled. Other values activate vehicle specific modes.
+
+
+PositionOffsetTargetMode:
+  datatype: uint8
+  type: actuator
+  description: Mode used for controlling position offset interface of axle steering actuator.
+               0 indicates interface disabled. Other values activate vehicle specific modes.
+
+
+#########################################################################################
+# RackPosition signals
+#########################################################################################
 
 RackPosition:
   datatype: int16
@@ -37,6 +45,13 @@ RackPosition:
   description: Represents the current position of the steering rack on axle steering actuator.
                Positive values leads to a left turn of the vehicle (based on ISO8855).
 
+RackPositionTargetMode:
+  deprecation: v5.2 - Replaced by PositionTargetMode.
+  datatype: uint8
+  type: actuator
+  description: Mode used for controlling rack position interface of axle steering actuator.
+               0 indicates interface disabled. Other values activate vehicle specific modes.
+
 RackPositionTarget:
   datatype: int16
   type: actuator
@@ -44,8 +59,47 @@ RackPositionTarget:
   description: Rack position request to the axle steering actuator (external set-point).
                Positive values lead to a left turn of the vehicle (based on ISO8855).
 
-RackPositionTargetMode:
+RackPositionOffsetTargetMode:
+  deprecation: v5.2 - Replaced by PositionOffsetTarget.
   datatype: uint8
   type: actuator
-  description: Mode used for controlling rack position interface of axle steering actuator.
+  description: Mode used for controlling rack position offset interface of axle steering actuator.
                0 indicates interface disabled. Other values activate vehicle specific modes.
+
+RackPositionOffsetTarget:
+  datatype: int16
+  type: actuator
+  unit: mm
+  description: Rack position offset request to the axle steering actuator (for steer-by-wire),
+               added to the actuator internal calculated set-point.
+               Positive values without internal calculated set point change lead to a left movement of the vehicle (based on ISO8855).
+
+
+#########################################################################################
+# SteerAngle signals
+#########################################################################################
+
+SteerAngle:
+  datatype: int16
+  type: sensor
+  unit: degrees
+  description: Represents the current actuated steering angle of the steered wheels.
+               Signal orientation according ISO8855, single track model.
+  comment: Alternative signal to RackPosition.
+
+SteerAngleTarget:
+  datatype: int16
+  type: actuator
+  unit: degrees
+  description: Steer angle request to the axle steering actuator (external set-point).
+               Signal orientation according ISO8855, single track model.
+  comment: Alternative signal to RackPositionTarget.
+
+SteerAngleOffsetTarget:
+  datatype: int16
+  type: actuator
+  unit: degrees
+  description: Steer angle offset request to the axle steering actuator (for steer-by-wire),
+               added to the actuator internal calculated set-point.
+               Signal orientation according ISO8855, single track model.
+  comment: Alternative signal to RackPositionOffsetTarget.


### PR DESCRIPTION
This is an extension of Motion management concept in VSS. Previously we had only rack position as an option for controlling wanted steering, this PR extends it to allow steering angle to be used as an alternative.

_The contribution was written within the Shift2SDV project (GA number 101194245) which is supported by the Chips Joint Undertaking and its members, including top-funding by the national authorities of Austria, Denmark, Germany, Greece, Finland, Italy, Netherlands, Poland, Portugal, Spain, Turkey. Co-funded by the European Union. Views and opinions expressed are however those of the author(s) only and do not necessarily reflect those of the European Union or the Chips Joint Undertaking. Neither the European Union nor the granting authorities can be held responsible for them._

