### PR TITLE
Adding motion management signals for rear wheel steering and suspension

### DIFF
--- a/docs-gen/content/catalog/vehicle_motion_management.md
+++ b/docs-gen/content/catalog/vehicle_motion_management.md
@@ -10,7 +10,7 @@ In modern vehicles multiple electronic controlled systems are interacting to rea
 Typically, the driver gives input e.g. using the steering wheel and the accelerator and brake pedals, but additional vehicle functions may have also requests towards the motion actuators.
 One example is that a traction control system may want to limit the performance due to slippery road conditions or that the emergency braking system requests braking.
 
-A number of signals have been added to VSS related to powertrain (eAxle), steering and braking.
+A number of signals have been added to VSS related to powertrain (eAxle), steering, suspension and braking.
 These signals may be used to define actuator interfaces to support a highly flexible functional deployment on different electronic control units.
 Vehicle motion functions like driver brake request, cooperative regenerative braking and traction control system may request target values for longitudinal control on vehicle, axle and wheel level.
 Therefore, generic interface signals for the braking systems are introduced which support an arbitration of the requested target values by minimum and maximum values.
@@ -51,6 +51,11 @@ If nothing else is specified, the following definitions and assumptions apply
   This means that a positive torque yields to a force in vehicle forward direction and a negative torque yields to a force in backward direction.
   Omega limits for eAxle system defined according. Positive sign for rotation in forward direction, negative sign for rotation in backward direction.
   So the sign of current omega of a eAxle indicated the current driving direction.
+
+* Signal orientation suspension system:
+  Requests are defined according to ISO 8855.
+  This means that a positive damping force is pointing upwards and a negative force is pointing downwards.
+  A positive roll torque indicates a torque that tends to depress the right-hand side of the vehicle and lift the left-hand side.
 
 * All signals are defined in an automotive safety context, i.e. ISO 26262 has to be considered while using specified signals in vehicle applications.
 

--- a/spec/Vehicle/MotionManagement.vspec
+++ b/spec/Vehicle/MotionManagement.vspec
@@ -32,3 +32,8 @@ MotionManagement.Steering:
   type: branch
   description: MotionManagement related to steering.
 #include MotionManagement/Steering.vspec MotionManagement.Steering
+
+MotionManagement.Suspension:
+  type: branch
+  description: MotionManagement related to suspension.
+#include MotionManagement/Suspension.vspec MotionManagement.Suspension

--- a/spec/Vehicle/MotionManagement/Steering.vspec
+++ b/spec/Vehicle/MotionManagement/Steering.vspec
@@ -32,9 +32,14 @@ SteeringWheel:
 
 Axle:
   type: branch
-  instances:
-    - Row[1,1]
   description: MotionManagement related to a specific axle.
-  comment: The instantiation only considers axles that are steerable.
-           Row[1,1] indicates that one axle is steerable, but does not indicate which axle.
-#include Steering/Axle.vspec Axle
+
+Axle.Row1:
+  type: branch
+  description: MotionManagement related to front axle.
+#include Steering/FrontAxle.vspec Axle.Row1
+
+Axle.Row2:
+  type: branch
+  description: MotionManagement related to rear axle.
+#include Steering/RearAxle.vspec Axle.Row2

--- a/spec/Vehicle/MotionManagement/Steering/FrontAxle.vspec
+++ b/spec/Vehicle/MotionManagement/Steering/FrontAxle.vspec
@@ -6,14 +6,6 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-# Copyright (c) 2024 Contributors to COVESA
-#
-# This program and the accompanying materials are made available under the
-# terms of the Mozilla Public License 2.0 which is available at
-# https://www.mozilla.org/en-US/MPL/2.0/
-#
-# SPDX-License-Identifier: MPL-2.0
-
 # See vehicle_motion_management.md for more info
 
 #########################################################################################
@@ -44,6 +36,7 @@ RackPosition:
   unit: mm
   description: Represents the current position of the steering rack on axle steering actuator.
                Positive values leads to a left turn of the vehicle (based on ISO8855).
+  comment: Alternative signal to SteerAngle.
 
 RackPositionTargetMode:
   deprecation: v5.2 - Replaced by PositionTargetMode.
@@ -58,6 +51,7 @@ RackPositionTarget:
   unit: mm
   description: Rack position request to the axle steering actuator (external set-point).
                Positive values lead to a left turn of the vehicle (based on ISO8855).
+  comment: Alternative signal to SteerAngleTarget.
 
 RackPositionOffsetTargetMode:
   deprecation: v5.2 - Replaced by PositionOffsetTarget.
@@ -73,6 +67,7 @@ RackPositionOffsetTarget:
   description: Rack position offset request to the axle steering actuator (for steer-by-wire),
                added to the actuator internal calculated set-point.
                Positive values without internal calculated set point change lead to a left movement of the vehicle (based on ISO8855).
+  comment: Alternative signal to SteerAngleOffsetTarget.
 
 
 #########################################################################################

--- a/spec/Vehicle/MotionManagement/Steering/RearAxle.vspec
+++ b/spec/Vehicle/MotionManagement/Steering/RearAxle.vspec
@@ -1,0 +1,36 @@
+# Copyright (c) 2025 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
+# See vehicle_motion_management.md for more info
+
+
+#########################################################################################
+# SteerAngle signals
+#########################################################################################
+
+SteerAngle:
+  datatype: int16
+  type: sensor
+  unit: degrees
+  description: Represents the current actuated steering angle of the steered wheels on rear axle.
+               Signal orientation according ISO8855, single track model.
+
+SteerAngleTarget:
+  datatype: int16
+  type: actuator
+  unit: degrees
+  description: Steer angle request to the rear axle steering actuator (external set-point).
+               Signal orientation according ISO8855, single track model.
+
+SteerAngleVelocityTarget:
+  datatype: int16
+  type: actuator
+  unit: degrees/s
+  description: Requested velocity for steer angle change.
+               Signal orientation according ISO8855.
+               Optional signal to adapt rear wheel steering closed loop control gain.

--- a/spec/Vehicle/MotionManagement/Steering/SteeringWheel.vspec
+++ b/spec/Vehicle/MotionManagement/Steering/SteeringWheel.vspec
@@ -6,14 +6,6 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-# Copyright (c) 2024 Contributors to COVESA
-#
-# This program and the accompanying materials are made available under the
-# terms of the Mozilla Public License 2.0 which is available at
-# https://www.mozilla.org/en-US/MPL/2.0/
-#
-# SPDX-License-Identifier: MPL-2.0
-
 # See vehicle_motion_management.md for more info
 
 Angle:

--- a/spec/Vehicle/MotionManagement/Suspension.vspec
+++ b/spec/Vehicle/MotionManagement/Suspension.vspec
@@ -1,0 +1,64 @@
+# Copyright (c) 2025 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
+# See vehicle_motion_management.md for more info
+
+
+DampingPrioTarget:
+  type: actuator
+  datatype: uint8
+  unit: percent
+  min: 0
+  max: 100
+  description: Prioritization target for damping control
+               0% = damping control by damping actuator (e.g. base functions)
+               100% = damping control by VMM system (e.g. vehicle dynamics)
+
+RollTorqueTarget:
+  type: actuator
+  datatype: int16
+  unit: Nm
+  description: Roll torque request on vehicle level.
+               Signal orientation according to ISO8855.
+
+RollPrioTarget:
+  type: actuator
+  datatype: uint8
+  unit: percent
+  min: 0
+  max: 100
+  description: Prioritization target for anti-roll control
+               0% = anti-roll control by anti-roll actuator (e.g. base function)
+               100% = anti-roll control by VMM system (e.g. vehicle dynamics)
+
+RollTorqueDistributionFrontMaximum:
+  type: actuator
+  datatype: uint8
+  unit: percent
+  min: 0
+  max: 100
+  description: Maximum distribution range request of roll torque to front axle.
+               0% = Complete roll torque shall be shifted to rear axle
+               100% = Complete roll torque may be shifted to front axle
+
+RollTorqueDistributionFrontMinimum:
+  type: actuator
+  datatype: uint8
+  unit: percent
+  min: 0
+  max: 100
+  description: Minimum distribution range request of roll torque to front axle.
+               0% = Complete roll torque may be shifted to rear axle
+               100% = Complete roll torque shall be shifted to front axle
+
+Axle:
+  type: branch
+  instances:
+    - Row[1,2]
+  description: MotionManagement for suspension for a specific axle.
+#include Suspension/Axle.vspec Axle

--- a/spec/Vehicle/MotionManagement/Suspension/Axle.vspec
+++ b/spec/Vehicle/MotionManagement/Suspension/Axle.vspec
@@ -1,0 +1,21 @@
+# Copyright (c) 2025 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
+
+RollTorque:
+  type: sensor
+  datatype: int16
+  unit: Nm
+  description: Actuated roll torque on this axle by anti-roll actuator.
+               Signal orientation according to ISO8855.
+
+Wheel:
+  type: branch
+  instances: ["Left","Right"]
+  description: MotionManagement signals for a specific wheel.
+#include Axle/Wheel.vspec Wheel

--- a/spec/Vehicle/MotionManagement/Suspension/Axle/Wheel.vspec
+++ b/spec/Vehicle/MotionManagement/Suspension/Axle/Wheel.vspec
@@ -1,0 +1,47 @@
+# Copyright (c) 2025 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
+# See vehicle_motion_management.md for more info
+
+DampingRateTarget:
+  type: actuator
+  datatype: uint8
+  min: 0
+  max: 100
+  unit: percent
+  description: Damping rate request at given wheel.
+               0% = lowest possible damping rate
+               100% = highest possible damping rate
+  comment: Alternative signal to DampingForceTarget.
+
+DampingRate:
+  type: sensor
+  datatype: uint8
+  min: 0
+  max: 100
+  unit: percent
+  description: Actuated damping rate at given wheel.
+               0% = lowest possible damping rate
+               100% = highest possible damping rate
+  comment: Alternative signal to DampingForce.
+
+DampingForceTarget:
+  type: actuator
+  datatype: int16
+  unit: N
+  description: Damping force request at given wheel.
+               Signal orientation according ISO8855, meaning positive force is pointing upwards.
+  comment: Alternative signal to DampingRateTarget.
+
+DampingForce:
+  type: sensor
+  datatype: int16
+  unit: N
+  description: Actuated damping force at given wheel.
+               Signal orientation according ISO8855, meaning positive force is pointing upwards.
+  comment: Alternative signal to DampingRate.


### PR DESCRIPTION
This is an extension of the vehicle motion management "sub-tree", adding support for rear wheel steering and suspension.
Not using the same signals for front and rear axle for steering as they typically are implemented differently, like no rack on rear axles.

Signed-off-by: Erik Jaegervall <erik.jaegervall@se.bosch.com>

_The contribution was written within the Shift2SDV project (GA number 101194245) which is supported by the Chips Joint Undertaking and its members, including top-funding by the national authorities of Austria, Denmark, Germany, Greece, Finland, Italy, Netherlands, Poland, Portugal, Spain, Turkey. Co-funded by the European Union. Views and opinions expressed are however those of the author(s) only and do not necessarily reflect those of the European Union or the Chips Joint Undertaking. Neither the European Union nor the granting authorities can be held responsible for them._