### PR TITLE
FOR DISCUSSION: Datatype syntax and representation

### DIFF
--- a/spec/Vehicle/Vehicle.vspec
+++ b/spec/Vehicle/Vehicle.vspec
@@ -14,6 +14,16 @@
 # VSS Versioning information
 #
 
+ExampleTimestamp:
+  datatype: VehicleDataTypes.Timestamp
+  type: sensor
+  description: Just an example.
+
+ExampleEnum:
+  datatype: VehicleDataTypes.MyExampleEnum
+  type: sensor
+  description: Just an example.
+
 VersionVSS:
   type: branch
   description: Supported Version of VSS.

--- a/spec/VehicleDataTypes.vspec
+++ b/spec/VehicleDataTypes.vspec
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
+VehicleDataTypes:
+  type: branch
+  description: Top-level branch for vehicle data types.
+
+# Assume that order matters, i.e. a type must be defined before being used by someone else
+
+#include VehicleDataTypes/Timestamp.vspec VehicleDataTypes
+#include VehicleDataTypes/ExampleConst.vspec VehicleDataTypes
+#include VehicleDataTypes/ExampleEnum.vspec VehicleDataTypes

--- a/spec/VehicleDataTypes/ExampleConst.vspec
+++ b/spec/VehicleDataTypes/ExampleConst.vspec
@@ -1,0 +1,21 @@
+# Copyright (c) 2026 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
+
+# We could support a const datatype
+# Allowed to be used in all places where a value is defined, like default/min/max
+# Tooling could check that the value specified (here 3) match the defined datatyoe (here uint8)
+# If used, tooling could check that the type specified here (i.e. uint8) is allowed as value for the entry using it
+#
+# Example - An int const is allowed for a float value, but not in opposite direction.
+
+MyExampleConst:
+  datatype: uint8
+  type: const
+  value: 3
+  description: Some const

--- a/spec/VehicleDataTypes/ExampleEnum.vspec
+++ b/spec/VehicleDataTypes/ExampleEnum.vspec
@@ -1,0 +1,28 @@
+# Copyright (c) 2026 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
+
+# If we define enums like this exporters and downstream projects have two options
+#
+# 1. Just replace all uses of it with the base type and values specified here
+# 2. Keep the enum, represent it in whatever mechanism the target env supports for enums
+
+MyExampleEnum:
+    datadype: uint8
+    type: enum
+    description: Lorem ipsum.
+    enum:
+        - name: NOT_AVAILABLE
+          description: Information about not available
+          value: VehicleDataTypes.MyExampleConst
+        - name: VALUE_2
+          description: Something else
+          value: 2
+        - name: VALUE_3
+          description: Yet omething else
+          value: 7

--- a/spec/VehicleDataTypes/Timestamp.vspec
+++ b/spec/VehicleDataTypes/Timestamp.vspec
@@ -1,0 +1,32 @@
+# Copyright (c) 2026 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
+Timestamp:
+  type: struct
+  description: A point in time.
+
+Timestamp.seconds:
+  type: property
+  datatype: int64
+  # int64 allows sentinel negative values (e.g. -1 = unknown/invalid) and
+  # matches the timespec / Protobuf Timestamp convention.
+  unit: unix-time
+  description: Unix epoch seconds.
+
+Timestamp.nanoseconds:
+  type: property
+  datatype: int64
+  # A uint32 would be sufficient numerically, but int64 avoids implicit
+  # type-promotion issues when combining with the seconds field.
+  # Nanoseconds in struct timespec are defined as long in POSIX, and
+  # this definition was historically adopted by the C standard.
+  min: 0
+  max: 999999999
+  # matches Protobuf Timestamp convention; range is [0, 1e9).
+  unit: ns
+  description: Nanosecond offset within the second.

--- a/spec/units.yaml
+++ b/spec/units.yaml
@@ -178,7 +178,11 @@ Ah:
   allowed-datatypes: ['numeric']
 
 # Duration
-
+ns:
+  definition: Duration measured in nanoseconds
+  unit: nanosecond
+  quantity: duration
+  allowed-datatypes: ['numeric']
 ms:
   definition: Duration measured in milliseconds
   unit: millisecond


### PR DESCRIPTION
We currently have ongoing discussion to add out first datatype (struct) to the catalog tree, as well as to support enums (see #873) and constants. I created this as a proposal on how we potentially could add structs/enums/consts to the catalog, building on our existing struct support. The changes in this PR does not work as of today.

Rough idea:

- Have a types subtree
- In that one refer to definition
- Follow rules from structs on how you can reference elems

Intention with this one is not to discuss the specific structs/enum/consts but rather the used syntax,