### PR TITLE
Add OilPressureStatus to CombustionEngine.vspec

### DIFF
--- a/spec/Powertrain/CombustionEngine.vspec
+++ b/spec/Powertrain/CombustionEngine.vspec
@@ -157,12 +157,13 @@ EngineOil.Temperature:
 EngineOil.PressureStatus:
   type: sensor
   description: Engine oil pressure status.  
-  datatype: uint8
-  enum: 
-    'NORMAL': 0  # Oil pressure as expected, within the nominal operating range.
-    'WARNING': 1 # Oil pressure is marginal or fluctuating; system may be operating in a degraded state.
-    'ALERT': 2   # Oil pressure has dropped below the critical safety threshold; immediate action required.
-    'ERROR': 3   # Invalid data received, sensor failure or electrical circuit fault.
+  datatype: string
+  allowed: [ 
+    'NORMAL',   # Oil pressure as expected, within the nominal operating range.
+    'WARNING',  # Oil pressure is marginal or fluctuating; system may be operating in a degraded state.
+    'ALERT',    # Oil pressure has dropped below the critical safety threshold; immediate action required.
+    'ERROR'     # Invalid data received, sensor failure or electrical circuit fault.
+  ]
 
 #
 # Engine coolant

--- a/spec/Powertrain/CombustionEngine.vspec
+++ b/spec/Powertrain/CombustionEngine.vspec
@@ -156,9 +156,9 @@ EngineOil.Temperature:
 
 EngineOil.PressureStatus:
   type: sensor
-  description: Engine oil pressure status.  
+  description: Engine oil pressure status.
   datatype: string
-  allowed: [ 
+  allowed: [
     'NORMAL',   # Oil pressure as expected, within the nominal operating range.
     'WARNING',  # Oil pressure is marginal or fluctuating; system may be operating in a degraded state.
     'ALERT',    # Oil pressure has dropped below the critical safety threshold; immediate action required.

--- a/spec/Powertrain/CombustionEngine.vspec
+++ b/spec/Powertrain/CombustionEngine.vspec
@@ -160,7 +160,7 @@ EngineOil.Pressure:
   allowed: [
     'LOW_PERSISTANT',  # Oil pressure below threshold persistant over time, immediate action required
     'LOW_WARNING',     # Oil pressure below threshold detected, inspection required
-    'NORMAL',          # Within normal range, no need for driver action    
+    'NORMAL',          # Within normal range, no need for driver action
     ]
   description: Engine oil pressure.
 

--- a/spec/Powertrain/CombustionEngine.vspec
+++ b/spec/Powertrain/CombustionEngine.vspec
@@ -154,15 +154,15 @@ EngineOil.Temperature:
   unit: Celsius
   description: EOT, Engine oil temperature.
 
-EngineOil.Pressure:
-  datatype: string
+EngineOil.PressureStatus:
   type: sensor
-  allowed: [
-    'LOW_PERSISTANT',  # Oil pressure below threshold persistant over time, immediate action required
-    'LOW_WARNING',     # Oil pressure below threshold detected, inspection required
-    'NORMAL',          # Within normal range, no need for driver action
-    ]
-  description: Engine oil pressure.
+  description: Engine oil pressure status.  
+  datatype: uint8
+  enum: 
+    'NORMAL': 0  # Oil pressure as expected, within the nominal operating range.
+    'WARNING': 1 # Oil pressure is marginal or fluctuating; system may be operating in a degraded state.
+    'ALERT': 2   # Oil pressure has dropped below the critical safety threshold; immediate action required.
+    'ERROR': 3   # Invalid data received, sensor failure or electrical circuit fault.
 
 #
 # Engine coolant

--- a/spec/Powertrain/CombustionEngine.vspec
+++ b/spec/Powertrain/CombustionEngine.vspec
@@ -154,6 +154,16 @@ EngineOil.Temperature:
   unit: Celsius
   description: EOT, Engine oil temperature.
 
+EngineOil.Pressure:
+  datatype: string
+  type: sensor
+  allowed: [
+    'LOW_PERSISTANT',  # Oil pressure below threshold persistant over time, immediate action required
+    'LOW_WARNING',     # Oil pressure below threshold detected, inspection required
+    'NORMAL',          # Within normal range, no need for driver action    
+    ]
+  description: Engine oil pressure.
+
 #
 # Engine coolant
 #


### PR DESCRIPTION
Signed-off-by: Kjell Inge Hestad <[ki@hestad.no](mailto:ki@hestad.no)>

Hi, my suggestion is to add support for oil pressure status. Relevant to be used for the Ctrl MC system - a motorcycle mcu based wiring solution for retrofit on older motorcycles, where I am looking to adhere to the VSS standard.