### PR TITLE
feat(exterior): add Vehicle.Exterior.RoadSurfaceCondition sensor signal

### DIFF
--- a/spec/Vehicle/Exterior.vspec
+++ b/spec/Vehicle/Exterior.vspec
@@ -30,3 +30,26 @@ LightIntensity:
   description: Light intensity outside the vehicle.
                0 = No light detected, 100 = Fully lit.
   comment: Mapping to physical units and calculation method is sensor specific.
+
+RoadSurfaceCondition:
+  datatype: string
+  type: sensor
+  allowed: [
+    'UNKNOWN',
+    'DRY',
+    'WET',
+    'SNOW',
+    'ICE',
+    'SLUSH',
+    'WET_ICE',
+    'LOOSE_GRAVEL'
+  ]
+  description: Assessed condition of the road surface beneath or ahead of the vehicle.
+  comment: >
+    Determination method is implementation specific. May be derived from
+    sensor fusion of Vehicle.ADAS.ESC.RoadFriction.MostProbable,
+    Vehicle.Exterior.AirTemperature, Vehicle.Body.Raindetection.Intensity,
+    and optional camera-based road surface classification.
+    UNKNOWN shall be used when the system cannot assess the road surface condition.
+    Primary consumers: navigation and ADAS safety systems.
+    Related to VSS issue #877 (Connected Safety signals).


### PR DESCRIPTION
## Summary

Contributes to #877 (Connected Safety signals). Adds `Vehicle.Exterior.RoadSurfaceCondition` sensor to `spec/Vehicle/Exterior.vspec`.

## Signal definition

```yaml
RoadSurfaceCondition:
  datatype: string
  type: sensor
  allowed: [UNKNOWN, DRY, WET, SNOW, ICE, SLUSH, WET_ICE, LOOSE_GRAVEL]
  description: Assessed condition of the road surface beneath or ahead of the vehicle.
```

## Rationale

Road surface condition is a primary input for navigation safety and ADAS systems. It is derivable from existing VSS signals:

- `Vehicle.ADAS.ESC.RoadFriction.MostProbable` (friction coefficient)
- `Vehicle.Exterior.AirTemperature` (freeze risk)
- `Vehicle.Body.Raindetection.Intensity` (wet surface)
- Optional: camera-based road surface classification

The 8 `allowed` values cover the full surface-type space used in ISO 26262 road hazard classifications and automotive weather-safety literature. `UNKNOWN` is required to represent sensor-fusion failure without leaving the signal unset.

## Placement

Appended after `LightIntensity` in `spec/Vehicle/Exterior.vspec` — consistent with the existing Exterior branch structure (ambient conditions).

---

*AI-assisted — authored with Claude, reviewed by Komada.*