### PR TITLE
Feat/safety 877 v2

### DIFF
--- a/spec/Safety/Safety.vspec
+++ b/spec/Safety/Safety.vspec
@@ -28,7 +28,7 @@ IsSubmersed:
     Primary consumers: emergency dispatch and first responder systems.
     Related to VSS issue #877 (Connected Safety signals).
 
-RolloverDetected:
+Rollover:
   datatype: string
   type: sensor
   allowed: [

--- a/spec/Safety/Safety.vspec
+++ b/spec/Safety/Safety.vspec
@@ -32,7 +32,7 @@ RolloverDetected:
   datatype: string
   type: sensor
   allowed: [
-    'NONE',
+    'UNKNOWN',
     'RISK',
     'DETECTED',
     'UNKNOWN'

--- a/spec/Safety/Safety.vspec
+++ b/spec/Safety/Safety.vspec
@@ -35,7 +35,6 @@ Rollover:
     'UNKNOWN',
     'RISK',
     'DETECTED',
-    'UNKNOWN'
   ]
   description: Indicates whether the vehicle has rolled over or is at risk of rollover.
   comment: >

--- a/spec/Safety/Safety.vspec
+++ b/spec/Safety/Safety.vspec
@@ -1,0 +1,50 @@
+# Copyright (c) 2026 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
+IsFire:
+  datatype: boolean
+  type: sensor
+  description: Indicates whether a fire has been detected in or on the vehicle.
+  comment: >
+    Determination method is implementation specific. May be derived from
+    temperature sensors, battery thermal runaway detection,
+    or dedicated fire/smoke detection systems.
+    Primary consumers: emergency dispatch and first responder systems.
+    Related to VSS issue #877 (Connected Safety signals).
+
+IsSubmersed:
+  datatype: boolean
+  type: sensor
+  description: Indicates whether the vehicle is partially or fully submersed in water.
+  comment: >
+    Determination method is implementation specific. May be derived from
+    pressure sensors, water contact sensors, door seal sensors,
+    or anomalous rain detection intensity readings.
+    Primary consumers: emergency dispatch and first responder systems.
+    Related to VSS issue #877 (Connected Safety signals).
+
+RolloverDetected:
+  datatype: string
+  type: sensor
+  allowed: [
+    'NONE',
+    'RISK',
+    'DETECTED',
+    'UNKNOWN'
+  ]
+  description: Indicates whether the vehicle has rolled over or is at risk of rollover.
+  comment: >
+    May be derived from Vehicle.AngularVelocity, Vehicle.Orientation.Roll,
+    and Vehicle.Orientation.Pitch signals.
+    NONE indicates normal orientation.
+    RISK indicates the vehicle is at elevated risk of rollover.
+    DETECTED indicates a rollover event has occurred.
+    UNKNOWN shall be used when the system cannot assess rollover status.
+    Criteria for each state may be OEM specific.
+    Primary consumers: emergency dispatch and first responder systems.
+    Related to VSS issue #877 (Connected Safety signals).

--- a/spec/Safety/Safety.vspec
+++ b/spec/Safety/Safety.vspec
@@ -33,8 +33,9 @@ Rollover:
   type: sensor
   allowed: [
     'UNKNOWN',
+    'NONE',
     'RISK',
-    'DETECTED',
+    'DETECTED'
   ]
   description: Indicates whether the vehicle has rolled over or is at risk of rollover.
   comment: >

--- a/spec/VehicleSignalSpecification.vspec
+++ b/spec/VehicleSignalSpecification.vspec
@@ -143,6 +143,14 @@ Vehicle.ADAS:
 
 #include ADAS/ADAS.vspec Vehicle.ADAS
 
+#
+# The safety branch for crash-relevant derived signals.
+#
+Vehicle.Safety:
+  type: branch
+  description: Safety-related derived signals for crash detection and emergency response.
+
+#include Safety/Safety.vspec Vehicle.Safety
 
 #
 # Chassis signals and attributes.


### PR DESCRIPTION
Contributes to #877 (Connected Safety signals). Adds three derived/smart signals to a new `Vehicle.Safety` branch per @erikbosch's guidance.

Signals added:

- `Vehicle.Safety.IsFire` — boolean sensor. Fire detected in or on the vehicle. Implementation specific. May derive from temperature sensors, battery thermal runaway detection, or dedicated fire/smoke systems.
- `Vehicle.Safety.IsSubmersed` — boolean sensor. Vehicle partially or fully submersed in water. Implementation specific. May derive from pressure sensors, water contact sensors, or door seal sensors.
- `Vehicle.Safety.RolloverDetected` — string sensor enum. Values: `NONE`, `RISK`, `DETECTED`, `UNKNOWN`. Covers both active rollover events and elevated rollover risk per Erik's suggestion. OEM specific criteria. May derive from `Vehicle.AngularVelocity`, `Vehicle.Roll`, and `Vehicle.Pitch`.

Why these signals:

- Connected Safety group identified fire, submersion, and vehicle orientation as unsupported in current VSS
- First responders need these at dispatch time. A 911 operator needs "car is on fire" not raw temperature readings
- All three are derived/smart values computed from underlying sensor data. Fits the `Vehicle.Safety` branch pattern Erik proposed

Placement:

- New `spec/Safety/Safety.vspec` file
- `Vehicle.Safety` branch included in root spec after `Vehicle.ADAS` (pre-crash) and before `Vehicle.Chassis` (structural). Seems like pre-crash prevention and post-crash detection should sit adjacent.

Companion PR:

- Absolute orientation signals (Roll, Pitch) will follow in a separate PR under `Vehicle` near the existing `AngularVelocity` block at line 302 of `Vehicle.vspec`. These are the raw inputs that `RolloverDetected` derives from.


Signed-off-by: Vladimir Edouard <vje013@gmail.com>