### PR TITLE
feat(vehicle): add Vehicle.Orientation branch with absolute roll, pitch, yaw

### DIFF
--- a/spec/Vehicle/Vehicle.vspec
+++ b/spec/Vehicle/Vehicle.vspec
@@ -322,6 +322,43 @@ AngularVelocity.Yaw:
   description: Vehicle rotation rate along Z (vertical).
 
 #
+# Spatial Orientation
+#
+Orientation:
+  type: branch
+  description: Spatial orientation. Axis definitions according to ISO 8855.
+
+Orientation.Roll:
+  datatype: float
+  type: sensor
+  unit: degrees
+  description: Vehicle rotation (tilt) around X (longitudinal). Positive values = right side down.
+  comment: >
+    Reference is the vehicle at rest on a level surface.
+    Useful for rollover detection and off-road applications.
+    Related to VSS Issue #877 (Connected Safety Signals).
+
+Orientation.Pitch:
+  datatype: float
+  type: sensor
+  unit: degrees
+  description: Vehicle rotation (tilt) around Y (lateral). Positive values = nose up.
+  comment: >
+    Reference is the vehicle at rest on a level surface.
+    Useful for incline detection and trailer loading applications.
+    Related to VSS Issue #877 (Connected Safety Signals).
+
+Orientation.Yaw:
+  datatype: float
+  type: sensor
+  unit: degrees
+  description: Vehicle rotation around Z (vertical) relative to geographic north.
+  comment: >
+    0 = North, 90 = East, 180 = South, 270 = West.
+    Complements CurrentLocation.Heading by providing IMU-derived orientation rather than GNSS-derived heading.
+    Related to VSS issue #877 (Connected Safety Signals).
+
+#
 # Schema from schema.org
 #
 

--- a/spec/VehicleSignalSpecification.vspec
+++ b/spec/VehicleSignalSpecification.vspec
@@ -143,6 +143,14 @@ Vehicle.ADAS:
 
 #include ADAS/ADAS.vspec Vehicle.ADAS
 
+#
+# The safety branch for crash-relevant derived signals.
+#
+Vehicle.Safety:
+  type: branch
+  description: Safety-related derived signals for crash detection and emergency response.
+
+#include Safety/Safety.vspec Vehicle.Safety
 
 #
 # Chassis signals and attributes.


### PR DESCRIPTION
Contributes to #877 (Connected Safety signals). Adds absolute orientation signals to complement the existing Vehicle.AngularVelocity (rate) signals, per guidance from @erikbosch.

Signals added:

- Vehicle.Orientation.Roll — float sensor, degrees. Vehicle tilt around
  X (longitudinal). Positive = right side down.
- Vehicle.Orientation.Pitch — float sensor, degrees. Vehicle tilt around
  Y (lateral). Positive = nose up.
- Vehicle.Orientation.Yaw — float sensor, degrees. Vehicle rotation around
  Z (vertical) relative to geographic north. IMU-derived complement to
  GNSS-based CurrentLocation.Heading.

Rationale:

- AngularVelocity measures rate of rotation (degrees/s) but not absolute
  position. A vehicle upside down in a ditch has zero angular velocity.
  Dispatchers need to know current orientation, not rotation rate.
- Same ISO 8855 axis convention and branch structure as AngularVelocity.
- Useful beyond crash response: off-road, trailer loading, parking assist,
  ADAS tilt compensation.
- Provides raw inputs for Vehicle.Safety.RolloverDetected (PR #894).

Placement:

- Added to spec/Vehicle/Vehicle.vspec after AngularVelocity and before
  RoofLoad, per Erik's guidance to place absolute orientation values
  near existing angular velocity signals.

Companion to PR #894 (Vehicle.Safety branch).