### PR TITLE
feat(units): Add QUDT unit and quantity kind correspondances

### DIFF
--- a/docs-gen/content/rule_set/data_entry/data_units.md
+++ b/docs-gen/content/rule_set/data_entry/data_units.md
@@ -107,6 +107,12 @@ please create a pull request where the new unit is added to
 If the unit is needed for a new signal in the VSS standard catalog you can propose the new signal and the new unit
 in the same Pull Request.
 
+## Reusing existing units and quantity kinds from QUDT
+
+
+
+The introduction of optional QUDT mappings in the unit definitions enables direct reuse of the extensive standard vocabulary provided by [QUDT (Quantities, Units, Dimensions, and Data Types)](https://qudt.org). By referencing QUDT units and quantity kinds, VSS can benefit from the rich metadata, standardized definitions, and available transformation formulas maintained by the QUDT community. This not only improves semantic interoperability but also allows for easier integration with external systems and tools that already leverage QUDT. With this approach, it is now possible to specify explicit mappings to QUDT units and quantity kinds, making it easier to leverage existing resources and ensure consistency across domains.
+
 ## Unit file syntax
 
 Unit files follow the syntax defined below:
@@ -117,8 +123,12 @@ Unit files follow the syntax defined below:
     definition: <string>
     [unit: <string>] # Full name of unit
     quantity: <string> # Quantity of the unit.
-    [allowed-datatypes] : ['numeric', 'string', uint8', ...]] # Allowed datatypes in VSS standard catalog
+    [allowed-datatypes] : ['numeric', 'string', 'uint8', ...] # Allowed datatypes in VSS standard catalog
     [deprecation: <reason>]
+    [qudt:                # Optional QUDT mapping for this unit
+      unit: <string>      # QUDT unit URI
+      quantity-kind: <string> # QUDT quantity kind URI
+    ]
 ]*
 ```
 
@@ -130,6 +140,7 @@ However, from a VSS perspective quantities do not need to correspond to physical
 It could be an arbitrary term, but it is generally expected that it is possible to convert between values
 using different units but defined with the same quantity.
 
+
 Example:
 
 ```yaml
@@ -138,12 +149,18 @@ m:
   unit: meter
   quantity: length
   allowed-datatypes: ['numeric']
+  qudt:
+    unit: http://qudt.org/vocab/unit/M
+    quantity-kind: https://qudt.org/vocab/quantitykind/Length
 
 mm:
   definition: Length measured in millimeters
   unit: millimeter
   quantity: length
   allowed-datatypes: ['numeric']
+  qudt:
+    unit: http://qudt.org/vocab/unit/MilliM
+    quantity-kind: https://qudt.org/vocab/quantitykind/Length
 ```
 
 As `m` and `mm` are defined with the same quantity it is expected that you can convert a value from `m` to `mm`.

--- a/spec/units.yaml
+++ b/spec/units.yaml
@@ -8,26 +8,36 @@ mm:
   unit: millimeter
   quantity: length
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/MilliM
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Length
 cm:
   definition: Length measured in centimeters
   unit: centimeter
   quantity: length
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/CentiM
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Length
 m:
   definition: Length measured in meters
   unit: meter
   quantity: length
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/M
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Length
 km:
   definition: Length measured in kilometers
   unit: kilometer
   quantity: length
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/KiloM
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Length
 inch:
   definition: Distance measured in inches
   unit: inch
   quantity: length
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/IN
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Length
 
 # Velocity
 
@@ -36,11 +46,15 @@ km/h:
   unit: kilometer per hour
   quantity: velocity
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/KiloM-PER-HR
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Velocity
 m/s:
   definition: Speed measured in meters per second
   unit: meters per second
   quantity: velocity
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/M-PER-SEC
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Velocity
 
 # Acceleration
 
@@ -49,11 +63,15 @@ m/s^2:
   unit: meters per second squared
   quantity: acceleration
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/M-PER-SEC2
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Acceleration
 cm/s^2:
   definition: Acceleration measured in centimeters per second squared
   unit: centimeters per second squared
   quantity: acceleration
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/CentiM-PER-SEC2
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Acceleration
 
 # Volume
 
@@ -62,16 +80,22 @@ ml:
   unit: milliliter
   quantity: volume
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/MilliL
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Volume
 l:
   definition: Volume measured in liters
   unit: liter
   quantity: volume
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/L
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Volume
 cm^3:
   definition: Volume measured in cubic centimeters
   unit: cubic centimeters
   quantity: volume
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/CentiM3
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Volume
 
 # Temperature
 
@@ -80,12 +104,16 @@ Celsius:
   unit: degree Celsius
   quantity: temperature
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/DEG_C
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Temperature
 
 Fahrenheit:
   definition: Temperature measured in degree Fahrenheit
   unit: degree Fahrenheit
   quantity: temperature
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/DEG_F
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Temperature
 
 # Angle
 
@@ -94,6 +122,8 @@ degrees:
   unit: degree
   quantity: angle
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/Degree
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Angle
 
 # Angular Speed
 
@@ -102,11 +132,15 @@ degrees/s:
   unit: degree per second
   quantity: angular-speed
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/DEG-PER-SEC
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/AngularVelocity
 rad/s:
   definition: Angular speed measured in radians per second
   unit: radians per second
   quantity: angular-speed
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/RAD-PER-SEC
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/AngularVelocity
 
 
 # Power
@@ -116,16 +150,22 @@ W:
   unit: watt
   quantity: power
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/W
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Power
 kW:
   definition: Power measured in kilowatts
   unit: kilowatt
   quantity: power
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/KiloW
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Power
 PS:
   definition: Power measured in horsepower
   unit: horsepower
   quantity: power
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/HP
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Power
 
 # Work
 
@@ -134,6 +174,8 @@ kWh:
   unit: kilowatt hours
   quantity: work
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/KiloW-HR
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Energy
 
 # Mass
 
@@ -142,16 +184,22 @@ g:
   unit: gram
   quantity: mass
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/GM
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Mass
 kg:
   definition: Mass measured in kilograms
   unit: kilogram
   quantity: mass
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/KiloGM
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Mass
 lbs:
   definition: Mass measured in pounds
   unit: pound
   quantity: mass
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/LB
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Mass
 
 # Voltage
 
@@ -160,6 +208,8 @@ V:
   unit: volt
   quantity: voltage
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/V
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Voltage
 
 # Electric Current
 
@@ -168,6 +218,8 @@ A:
   unit: ampere
   quantity: electric-current
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/A
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/ElectricCurrent
 
 # Electric Charge
 
@@ -176,6 +228,8 @@ Ah:
   unit: ampere hours
   quantity: electric-charge
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/A_HR
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/ElectricCharge
 
 # Duration
 
@@ -184,46 +238,64 @@ ns:
   unit: nanosecond
   quantity: duration
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/NanoSEC
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Time
 ms:
   definition: Duration measured in milliseconds
   unit: millisecond
   quantity: duration
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/MilliSEC
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Time
 s:
   definition: Duration measured in seconds
   unit: second
   quantity: duration
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/SEC
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Time
 min:
   unit: minute
   definition: Duration measured in minutes
   quantity: duration
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/MIN
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Time
 h:
   definition: Duration measured in hours
   unit: hour
   quantity: duration
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/HR
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Time
 day:
   definition: Duration measured in days
   unit: days
   quantity: duration
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/DAY
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Time
 weeks:
   definition: Duration measured in weeks
   unit: weeks
   quantity: duration
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/WK
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Time
 months:
   definition: Duration measured in months
   unit: months
   quantity: duration
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/MO
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Time
 years:
   definition: Duration measured in years
   unit: years
   quantity: duration
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/YR
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Time
 
 # Datetime
 
@@ -245,21 +317,29 @@ mbar:
   unit: millibar
   quantity: pressure
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/MilliBAR
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/VaporPressure
 Pa:
   definition: Pressure measured in pascal
   unit: pascal
   quantity: pressure
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/PA
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/VaporPressure
 kPa:
   definition: Pressure measured in kilopascal
   unit: kilopascal
   quantity: pressure
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/KiloPA
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/VaporPressure
 psi:
   definition: Pressure measured in pounds per square inch
   unit: pounds per square inch
   quantity: pressure
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/PSI
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/VaporPressure
 
 # Rating
 
@@ -276,6 +356,8 @@ g/s:
   unit: grams per second
   quantity: mass-per-time
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/GM-PER-SEC
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/MassFlowRate
 
 # Mass per distance
 
@@ -284,6 +366,8 @@ g/km:
   unit: grams per kilometer
   quantity: mass-per-distance
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/GM-PER-KiloM
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/MassPerLength
 
 # Energy consumption per distance
 
@@ -318,6 +402,8 @@ l/h:
   unit: liter per hour
   quantity: volume-flow-rate
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/L-PER-HR
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/VolumeFlowRate
 
 # Distance per volume
 
@@ -355,11 +441,15 @@ N:
   unit: newton
   quantity: force
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/N
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Force
 kN:
   unit: kilo newton
   definition: Force measured in kilo newton
   quantity: force
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/KiloN
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Force
 
 # Torque
 
@@ -368,6 +458,8 @@ Nm:
   unit: newton meter
   quantity: torque
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/N-M
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Torque
 
 # Rotational Speed
 
@@ -376,6 +468,8 @@ rpm:
   unit: revolutions per minute
   quantity: rotational-speed
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/REV-PER-MIN
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/RotationalVelocity
 
 # Frequency
 
@@ -384,6 +478,8 @@ Hz:
   unit: Hertz
   quantity: frequency
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/HZ
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Frequency
 cpm:
   definition: Number of cycles per minute
   unit: cycles per minute
@@ -394,6 +490,8 @@ bpm:
   unit: beats per minute
   quantity: frequency
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/BEAT-PER-MIN
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/HeartRate
 
 # Relation
 
@@ -402,11 +500,15 @@ ratio:
   unit: ratio
   quantity: relation
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/ONE-PER-ONE
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/DimensionlessRatio
 percent:
   definition: Relation measured in percent
   unit: percent
   quantity: relation
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/PERCENT
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/DimensionlessRatio
 nm/km:
   definition: nm/km
   unit: nano meter per kilometer
@@ -417,11 +519,15 @@ dBm:
   unit: decibel milliwatt
   quantity: relation
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/DeciB-MilliW
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Unknown
 dB:
   definition: Ratio of two values of a physical quantity, usually power or intensity, on a logarithmic scale.
   unit: decibel
   quantity: relation
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/DeciB
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/SoundPowerLevel
 
 # Resistance
 
@@ -430,6 +536,8 @@ Ohm:
   unit: Ohm
   quantity: resistance
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/OHM
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Resistance
 
 # Illuminance
 
@@ -438,3 +546,5 @@ lx:
   unit: lux
   quantity: illuminance
   allowed-datatypes: ['numeric']
+  qudt-unit: http://qudt.org/vocab/unit/LUX
+  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/LuminousFluxPerArea

--- a/spec/units.yaml
+++ b/spec/units.yaml
@@ -8,36 +8,41 @@ mm:
   unit: millimeter
   quantity: length
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/MilliM
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Length
+  qudt:
+    unit: http://qudt.org/vocab/unit/MilliM
+    quantity-kind: https://qudt.org/vocab/quantitykind/Length
 cm:
   definition: Length measured in centimeters
   unit: centimeter
   quantity: length
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/CentiM
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Length
+  qudt:
+    unit: http://qudt.org/vocab/unit/CentiM
+    quantity-kind: https://qudt.org/vocab/quantitykind/Length
 m:
   definition: Length measured in meters
   unit: meter
   quantity: length
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/M
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Length
+  qudt:
+    unit: http://qudt.org/vocab/unit/M
+    quantity-kind: https://qudt.org/vocab/quantitykind/Length
 km:
   definition: Length measured in kilometers
   unit: kilometer
   quantity: length
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/KiloM
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Length
+  qudt:
+    unit: http://qudt.org/vocab/unit/KiloM
+    quantity-kind: https://qudt.org/vocab/quantitykind/Length
 inch:
   definition: Distance measured in inches
   unit: inch
   quantity: length
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/IN
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Length
+  qudt:
+    unit: http://qudt.org/vocab/unit/IN
+    quantity-kind: https://qudt.org/vocab/quantitykind/Length
 
 # Velocity
 
@@ -46,15 +51,17 @@ km/h:
   unit: kilometer per hour
   quantity: velocity
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/KiloM-PER-HR
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Velocity
+  qudt:
+    unit: http://qudt.org/vocab/unit/KiloM-PER-HR
+    quantity-kind: https://qudt.org/vocab/quantitykind/Velocity
 m/s:
   definition: Speed measured in meters per second
   unit: meters per second
   quantity: velocity
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/M-PER-SEC
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Velocity
+  qudt:
+    unit: http://qudt.org/vocab/unit/M-PER-SEC
+    quantity-kind: https://qudt.org/vocab/quantitykind/Velocity
 
 # Acceleration
 
@@ -63,15 +70,17 @@ m/s^2:
   unit: meters per second squared
   quantity: acceleration
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/M-PER-SEC2
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Acceleration
+  qudt:
+    unit: http://qudt.org/vocab/unit/M-PER-SEC2
+    quantity-kind: https://qudt.org/vocab/quantitykind/Acceleration
 cm/s^2:
   definition: Acceleration measured in centimeters per second squared
   unit: centimeters per second squared
   quantity: acceleration
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/CentiM-PER-SEC2
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Acceleration
+  qudt:
+    unit: http://qudt.org/vocab/unit/CentiM-PER-SEC2
+    quantity-kind: https://qudt.org/vocab/quantitykind/Acceleration
 
 # Volume
 
@@ -80,22 +89,25 @@ ml:
   unit: milliliter
   quantity: volume
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/MilliL
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Volume
+  qudt:
+    unit: http://qudt.org/vocab/unit/MilliL
+    quantity-kind: https://qudt.org/vocab/quantitykind/Volume
 l:
   definition: Volume measured in liters
   unit: liter
   quantity: volume
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/L
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Volume
+  qudt:
+    unit: http://qudt.org/vocab/unit/L
+    quantity-kind: https://qudt.org/vocab/quantitykind/Volume
 cm^3:
   definition: Volume measured in cubic centimeters
   unit: cubic centimeters
   quantity: volume
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/CentiM3
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Volume
+  qudt:
+    unit: http://qudt.org/vocab/unit/CentiM3
+    quantity-kind: https://qudt.org/vocab/quantitykind/Volume
 
 # Temperature
 
@@ -104,16 +116,18 @@ Celsius:
   unit: degree Celsius
   quantity: temperature
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/DEG_C
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Temperature
+  qudt:
+    unit: http://qudt.org/vocab/unit/DEG_C
+    quantity-kind: https://qudt.org/vocab/quantitykind/Temperature
 
 Fahrenheit:
   definition: Temperature measured in degree Fahrenheit
   unit: degree Fahrenheit
   quantity: temperature
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/DEG_F
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Temperature
+  qudt:
+    unit: http://qudt.org/vocab/unit/DEG_F
+    quantity-kind: https://qudt.org/vocab/quantitykind/Temperature
 
 # Angle
 
@@ -122,8 +136,9 @@ degrees:
   unit: degree
   quantity: angle
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/Degree
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Angle
+  qudt:
+    unit: http://qudt.org/vocab/unit/Degree
+    quantity-kind: https://qudt.org/vocab/quantitykind/Angle
 
 # Angular Speed
 
@@ -132,15 +147,17 @@ degrees/s:
   unit: degree per second
   quantity: angular-speed
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/DEG-PER-SEC
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/AngularVelocity
+  qudt:
+    unit: http://qudt.org/vocab/unit/DEG-PER-SEC
+    quantity-kind: https://qudt.org/vocab/quantitykind/AngularVelocity
 rad/s:
   definition: Angular speed measured in radians per second
   unit: radians per second
   quantity: angular-speed
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/RAD-PER-SEC
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/AngularVelocity
+  qudt:
+    unit: http://qudt.org/vocab/unit/RAD-PER-SEC
+    quantity-kind: https://qudt.org/vocab/quantitykind/AngularVelocity
 
 
 # Power
@@ -150,22 +167,25 @@ W:
   unit: watt
   quantity: power
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/W
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Power
+  qudt:
+    unit: http://qudt.org/vocab/unit/W
+    quantity-kind: https://qudt.org/vocab/quantitykind/Power
 kW:
   definition: Power measured in kilowatts
   unit: kilowatt
   quantity: power
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/KiloW
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Power
+  qudt:
+    unit: http://qudt.org/vocab/unit/KiloW
+    quantity-kind: https://qudt.org/vocab/quantitykind/Power
 PS:
   definition: Power measured in horsepower
   unit: horsepower
   quantity: power
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/HP
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Power
+  qudt:
+    unit: http://qudt.org/vocab/unit/HP
+    quantity-kind: https://qudt.org/vocab/quantitykind/Power
 
 # Work
 
@@ -174,8 +194,9 @@ kWh:
   unit: kilowatt hours
   quantity: work
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/KiloW-HR
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Energy
+  qudt:
+    unit: http://qudt.org/vocab/unit/KiloW-HR
+    quantity-kind: https://qudt.org/vocab/quantitykind/Energy
 
 # Mass
 
@@ -184,22 +205,25 @@ g:
   unit: gram
   quantity: mass
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/GM
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Mass
+  qudt:
+    unit: http://qudt.org/vocab/unit/GM
+    quantity-kind: https://qudt.org/vocab/quantitykind/Mass
 kg:
   definition: Mass measured in kilograms
   unit: kilogram
   quantity: mass
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/KiloGM
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Mass
+  qudt:
+    unit: http://qudt.org/vocab/unit/KiloGM
+    quantity-kind: https://qudt.org/vocab/quantitykind/Mass
 lbs:
   definition: Mass measured in pounds
   unit: pound
   quantity: mass
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/LB
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Mass
+  qudt:
+    unit: http://qudt.org/vocab/unit/LB
+    quantity-kind: https://qudt.org/vocab/quantitykind/Mass
 
 # Voltage
 
@@ -208,8 +232,9 @@ V:
   unit: volt
   quantity: voltage
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/V
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Voltage
+  qudt:
+    unit: http://qudt.org/vocab/unit/V
+    quantity-kind: https://qudt.org/vocab/quantitykind/Voltage
 
 # Electric Current
 
@@ -218,8 +243,9 @@ A:
   unit: ampere
   quantity: electric-current
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/A
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/ElectricCurrent
+  qudt:
+    unit: http://qudt.org/vocab/unit/A
+    quantity-kind: https://qudt.org/vocab/quantitykind/ElectricCurrent
 
 # Electric Charge
 
@@ -228,8 +254,9 @@ Ah:
   unit: ampere hours
   quantity: electric-charge
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/A_HR
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/ElectricCharge
+  qudt:
+    unit: http://qudt.org/vocab/unit/A_HR
+    quantity-kind: https://qudt.org/vocab/quantitykind/ElectricCharge
 
 # Duration
 
@@ -238,64 +265,73 @@ ns:
   unit: nanosecond
   quantity: duration
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/NanoSEC
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Time
+  qudt:
+    unit: http://qudt.org/vocab/unit/NanoSEC
+    quantity-kind: https://qudt.org/vocab/quantitykind/Time
 ms:
   definition: Duration measured in milliseconds
   unit: millisecond
   quantity: duration
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/MilliSEC
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Time
+  qudt:
+    unit: http://qudt.org/vocab/unit/MilliSEC
+    quantity-kind: https://qudt.org/vocab/quantitykind/Time
 s:
   definition: Duration measured in seconds
   unit: second
   quantity: duration
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/SEC
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Time
+  qudt:
+    unit: http://qudt.org/vocab/unit/SEC
+    quantity-kind: https://qudt.org/vocab/quantitykind/Time
 min:
   unit: minute
   definition: Duration measured in minutes
   quantity: duration
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/MIN
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Time
+  qudt:
+    unit: http://qudt.org/vocab/unit/MIN
+    quantity-kind: https://qudt.org/vocab/quantitykind/Time
 h:
   definition: Duration measured in hours
   unit: hour
   quantity: duration
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/HR
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Time
+  qudt:
+    unit: http://qudt.org/vocab/unit/HR
+    quantity-kind: https://qudt.org/vocab/quantitykind/Time
 day:
   definition: Duration measured in days
   unit: days
   quantity: duration
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/DAY
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Time
+  qudt:
+    unit: http://qudt.org/vocab/unit/DAY
+    quantity-kind: https://qudt.org/vocab/quantitykind/Time
 weeks:
   definition: Duration measured in weeks
   unit: weeks
   quantity: duration
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/WK
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Time
+  qudt:
+    unit: http://qudt.org/vocab/unit/WK
+    quantity-kind: https://qudt.org/vocab/quantitykind/Time
 months:
   definition: Duration measured in months
   unit: months
   quantity: duration
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/MO
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Time
+  qudt:
+    unit: http://qudt.org/vocab/unit/MO
+    quantity-kind: https://qudt.org/vocab/quantitykind/Time
 years:
   definition: Duration measured in years
   unit: years
   quantity: duration
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/YR
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Time
+  qudt:
+    unit: http://qudt.org/vocab/unit/YR
+    quantity-kind: https://qudt.org/vocab/quantitykind/Time
 
 # Datetime
 
@@ -317,29 +353,33 @@ mbar:
   unit: millibar
   quantity: pressure
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/MilliBAR
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/VaporPressure
+  qudt:
+    unit: http://qudt.org/vocab/unit/MilliBAR
+    quantity-kind: https://qudt.org/vocab/quantitykind/VaporPressure
 Pa:
   definition: Pressure measured in pascal
   unit: pascal
   quantity: pressure
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/PA
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/VaporPressure
+  qudt:
+    unit: http://qudt.org/vocab/unit/PA
+    quantity-kind: https://qudt.org/vocab/quantitykind/VaporPressure
 kPa:
   definition: Pressure measured in kilopascal
   unit: kilopascal
   quantity: pressure
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/KiloPA
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/VaporPressure
+  qudt:
+    unit: http://qudt.org/vocab/unit/KiloPA
+    quantity-kind: https://qudt.org/vocab/quantitykind/VaporPressure
 psi:
   definition: Pressure measured in pounds per square inch
   unit: pounds per square inch
   quantity: pressure
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/PSI
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/VaporPressure
+  qudt:
+    unit: http://qudt.org/vocab/unit/PSI
+    quantity-kind: https://qudt.org/vocab/quantitykind/VaporPressure
 
 # Rating
 
@@ -356,8 +396,9 @@ g/s:
   unit: grams per second
   quantity: mass-per-time
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/GM-PER-SEC
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/MassFlowRate
+  qudt:
+    unit: http://qudt.org/vocab/unit/GM-PER-SEC
+    quantity-kind: https://qudt.org/vocab/quantitykind/MassFlowRate
 
 # Mass per distance
 
@@ -366,8 +407,9 @@ g/km:
   unit: grams per kilometer
   quantity: mass-per-distance
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/GM-PER-KiloM
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/MassPerLength
+  qudt:
+    unit: http://qudt.org/vocab/unit/GM-PER-KiloM
+    quantity-kind: https://qudt.org/vocab/quantitykind/MassPerLength
 
 # Energy consumption per distance
 
@@ -402,8 +444,9 @@ l/h:
   unit: liter per hour
   quantity: volume-flow-rate
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/L-PER-HR
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/VolumeFlowRate
+  qudt:
+    unit: http://qudt.org/vocab/unit/L-PER-HR
+    quantity-kind: https://qudt.org/vocab/quantitykind/VolumeFlowRate
 
 # Distance per volume
 
@@ -441,15 +484,17 @@ N:
   unit: newton
   quantity: force
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/N
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Force
+  qudt:
+    unit: http://qudt.org/vocab/unit/N
+    quantity-kind: https://qudt.org/vocab/quantitykind/Force
 kN:
   unit: kilo newton
   definition: Force measured in kilo newton
   quantity: force
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/KiloN
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Force
+  qudt:
+    unit: http://qudt.org/vocab/unit/KiloN
+    quantity-kind: https://qudt.org/vocab/quantitykind/Force
 
 # Torque
 
@@ -458,8 +503,9 @@ Nm:
   unit: newton meter
   quantity: torque
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/N-M
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Torque
+  qudt:
+    unit: http://qudt.org/vocab/unit/N-M
+    quantity-kind: https://qudt.org/vocab/quantitykind/Torque
 
 # Rotational Speed
 
@@ -468,8 +514,9 @@ rpm:
   unit: revolutions per minute
   quantity: rotational-speed
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/REV-PER-MIN
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/RotationalVelocity
+  qudt:
+    unit: http://qudt.org/vocab/unit/REV-PER-MIN
+    quantity-kind: https://qudt.org/vocab/quantitykind/RotationalVelocity
 
 # Frequency
 
@@ -478,8 +525,9 @@ Hz:
   unit: Hertz
   quantity: frequency
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/HZ
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Frequency
+  qudt:
+    unit: http://qudt.org/vocab/unit/HZ
+    quantity-kind: https://qudt.org/vocab/quantitykind/Frequency
 cpm:
   definition: Number of cycles per minute
   unit: cycles per minute
@@ -490,8 +538,9 @@ bpm:
   unit: beats per minute
   quantity: frequency
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/BEAT-PER-MIN
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/HeartRate
+  qudt:
+    unit: http://qudt.org/vocab/unit/BEAT-PER-MIN
+    quantity-kind: https://qudt.org/vocab/quantitykind/HeartRate
 
 # Relation
 
@@ -500,15 +549,17 @@ ratio:
   unit: ratio
   quantity: relation
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/ONE-PER-ONE
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/DimensionlessRatio
+  qudt:
+    unit: http://qudt.org/vocab/unit/ONE-PER-ONE
+    quantity-kind: https://qudt.org/vocab/quantitykind/DimensionlessRatio
 percent:
   definition: Relation measured in percent
   unit: percent
   quantity: relation
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/PERCENT
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/DimensionlessRatio
+  qudt:
+    unit: http://qudt.org/vocab/unit/PERCENT
+    quantity-kind: https://qudt.org/vocab/quantitykind/DimensionlessRatio
 nm/km:
   definition: nm/km
   unit: nano meter per kilometer
@@ -519,15 +570,17 @@ dBm:
   unit: decibel milliwatt
   quantity: relation
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/DeciB-MilliW
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Unknown
+  qudt:
+    unit: http://qudt.org/vocab/unit/DeciB-MilliW
+    quantity-kind: https://qudt.org/vocab/quantitykind/Unknown
 dB:
   definition: Ratio of two values of a physical quantity, usually power or intensity, on a logarithmic scale.
   unit: decibel
   quantity: relation
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/DeciB
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/SoundPowerLevel
+  qudt:
+    unit: http://qudt.org/vocab/unit/DeciB
+    quantity-kind: https://qudt.org/vocab/quantitykind/SoundPowerLevel
 
 # Resistance
 
@@ -536,8 +589,9 @@ Ohm:
   unit: Ohm
   quantity: resistance
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/OHM
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/Resistance
+  qudt:
+    unit: http://qudt.org/vocab/unit/OHM
+    quantity-kind: https://qudt.org/vocab/quantitykind/Resistance
 
 # Illuminance
 
@@ -546,5 +600,6 @@ lx:
   unit: lux
   quantity: illuminance
   allowed-datatypes: ['numeric']
-  qudt-unit: http://qudt.org/vocab/unit/LUX
-  qudt-quantity-kind: https://qudt.org/vocab/quantitykind/LuminousFluxPerArea
+  qudt:
+    unit: http://qudt.org/vocab/unit/LUX
+    quantity-kind: https://qudt.org/vocab/quantitykind/LuminousFluxPerArea


### PR DESCRIPTION
Adds external reference to unit model [QUDT](https://qudt.org/) as explained in #828 

For example: 

the unit kilometer `km` points to its correspondence https://qudt.org/vocab/unit/KiloM which has lots of extra metadata like translated labels, and conversion formulas. 