### PR TITLE
Prepare makefile for avro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,13 @@
 # Makefile to generate specifications
 #
 
-.PHONY: clean all mandatory_targets json franca yaml csv ddsidl tests binary protobuf ttl s2dm ocf c overlays id jsonschema
+.PHONY: clean all avro mandatory_targets json franca yaml csv ddsidl tests binary protobuf ttl s2dm ocf c overlays id jsonschema
 
 all: clean mandatory_targets optional_targets
 
 # All mandatory targets that shall be built and pass on each pull request for
 # vehicle-signal-specification or vss-tools
-mandatory_targets: clean apigear binary csv datatypes ddsidl franca go id json json-noexpand jsonschema overlays plantuml samm s2dm yaml
+mandatory_targets: clean apigear avro binary csv datatypes ddsidl franca go id json json-noexpand jsonschema overlays plantuml samm s2dm yaml
 
 # Additional targets that shall be built by travis, but where it is not mandatory
 # that the builds shall pass.
@@ -33,6 +33,9 @@ datatypes:
 apigear:
 	vspec export apigear ${COMMON_ARGS} ${COMMON_VSPEC_ARG} --output-dir apigear
 	cd apigear && tar -czvf ../vss_apigear.tar.gz * && cd ..
+
+avro:
+	vspec export avro ${COMMON_ARGS} ${COMMON_VSPEC_ARG} ${COMMON_DATATYPES_ARG} -o avro --namespace xxx
 
 binary:
 	vspec export binary ${COMMON_ARGS} ${COMMON_VSPEC_ARG} -o vss.binary


### PR DESCRIPTION
This is a follow up for https://github.com/COVESA/vss-tools/pull/520

What we can discuss is release artifacts - if it (as of today) makes sense to include avro as a release artifact (see https://github.com/COVESA/vehicle_signal_specification/blob/master/.github/workflows/buildcheck.yml#L47), if so we may need to think more about arguments like namespace. For now assuming that it does not make sense to add it as a release artifact. Will add a separate ticket to discuss release artifacts.

