### PR TITLE
feat(safety): add WhiteoutRisk + RoadIcingRisk signals (#877)

### DIFF
--- a/spec/Safety/Safety.vspec
+++ b/spec/Safety/Safety.vspec
@@ -48,3 +48,51 @@ Rollover:
     Criteria for each state may be OEM specific.
     Primary consumers: emergency dispatch and first responder systems.
     Related to VSS issue #877 (Connected Safety signals).
+
+WhiteoutRisk:
+  datatype: string
+  type: sensor
+  allowed: [
+    'UNKNOWN',
+    'NONE',
+    'RISK',
+    'DETECTED'
+  ]
+  description: Indicates whether the vehicle is in or approaching whiteout driving conditions (severely reduced visibility from blowing snow).
+  comment: >
+    May be derived from sensor fusion of Vehicle.Body.Raindetection.Intensity,
+    forward-camera visibility metrics, Vehicle.Exterior.AirTemperature, and
+    Vehicle.Exterior.RoadSurfaceCondition (SNOW state).
+    NONE indicates normal visibility.
+    RISK indicates conditions suggest whiteout may occur (e.g. heavy snow with wind).
+    DETECTED indicates whiteout currently degrades driver visibility below safe operating range.
+    UNKNOWN shall be used when the system cannot assess whiteout status.
+    Criteria for each state may be OEM specific.
+    Primary consumers: ADAS warning systems, navigation re-routing,
+    and driver-alert subsystems.
+    Related to VSS issue #877 (Connected Safety signals).
+
+RoadIcingRisk:
+  datatype: string
+  type: sensor
+  allowed: [
+    'UNKNOWN',
+    'NONE',
+    'RISK',
+    'DETECTED'
+  ]
+  description: Indicates the forecast or imminent risk of road-surface icing conditions ahead of or beneath the vehicle.
+  comment: >
+    Complements Vehicle.Exterior.RoadSurfaceCondition (which describes the
+    currently-detected surface state) by providing a predictive risk level.
+    May be derived from Vehicle.Exterior.AirTemperature trending toward freezing,
+    Vehicle.Body.Raindetection.Intensity history, dew-point estimation,
+    weather-service overlays, or upstream-vehicle telemetry sharing.
+    NONE indicates no current or imminent icing risk.
+    RISK indicates conditions suggest icing may form (e.g. near-freezing with moisture).
+    DETECTED indicates icing is currently forming or imminent on the driving surface.
+    UNKNOWN shall be used when the system cannot assess icing risk.
+    Criteria for each state may be OEM specific.
+    Primary consumers: ADAS predictive-braking systems, navigation re-routing,
+    and driver-alert subsystems.
+    Related to VSS issue #877 (Connected Safety signals).


### PR DESCRIPTION
Adds two predictive-class signals to `Vehicle.Safety`, both following the `UNKNOWN/NONE/RISK/DETECTED` enum pattern established by `Rollover` (#894):

- **WhiteoutRisk** — assesses whether the vehicle is in or approaching whiteout driving conditions (severely reduced visibility from blowing snow). Derived from sensor fusion across raindetection, forward-camera visibility, air temperature, and `Vehicle.Exterior.RoadSurfaceCondition` SNOW state.

- **RoadIcingRisk** — forecast / imminent-risk assessment of road-surface icing. Complements `Vehicle.Exterior.RoadSurfaceCondition` (#892), which describes the currently-detected surface state (DRY/WET/SNOW/ICE/SLUSH/WET_ICE/...); RoadIcingRisk adds the predictive layer (RISK = conditions suggest icing may form; DETECTED = icing currently forming or imminent) without duplicating the current-state classification.

Both serve ADAS warning systems, navigation re-routing, and driver-alert subsystems — the predictive layer of the Connected Safety signals tracked in #877.

Refs #877, #892, #894.

*AI-assisted — authored with Claude, reviewed by Komada.*