### PR TITLE
feat(safety): add VisibilityImpairment + RoadIcingState derived-assessment signals

### DIFF
--- a/spec/Safety/Safety.vspec
+++ b/spec/Safety/Safety.vspec
@@ -49,7 +49,7 @@ Rollover:
     Primary consumers: emergency dispatch and first responder systems.
     Related to VSS issue #877 (Connected Safety signals).
 
-WhiteoutRisk:
+Whiteout:
   datatype: string
   type: sensor
   allowed: [
@@ -61,9 +61,9 @@ WhiteoutRisk:
   description: Indicates whether the vehicle is currently affected by whiteout conditions (severe visibility loss from heavy snow, blowing snow, or fog) or is at risk of entering such conditions.
   comment: >
     May be derived from Vehicle.Exterior.RoadSurfaceCondition,
-    Vehicle.Exterior.AirTemperature, Vehicle.Body.Raindetection.Intensity,
-    Vehicle.ADAS.* visibility-class signals, and optional camera-based
-    visibility classification.
+    Vehicle.Exterior.AirTemperature, and Vehicle.Body.Raindetection.Intensity,
+    optionally combined with camera-based visibility classification.
+    The camera-based classification method is implementation specific.
     NONE indicates normal visibility conditions.
     RISK indicates elevated risk of visibility loss (e.g., heavy snow
     onset, blowing snow conditions developing).

--- a/spec/Safety/Safety.vspec
+++ b/spec/Safety/Safety.vspec
@@ -49,7 +49,7 @@ Rollover:
     Primary consumers: emergency dispatch and first responder systems.
     Related to VSS issue #877 (Connected Safety signals).
 
-Whiteout:
+VisibilityImpairment:
   datatype: string
   type: sensor
   allowed: [
@@ -58,23 +58,26 @@ Whiteout:
     'RISK',
     'DETECTED'
   ]
-  description: Indicates whether the vehicle is currently affected by whiteout conditions (severe visibility loss from heavy snow, blowing snow, or fog) or is at risk of entering such conditions.
+  description: Indicates whether reduced exterior visibility is currently creating a driving-safety risk, or such a condition has been detected.
   comment: >
-    May be derived from Vehicle.Exterior.RoadSurfaceCondition,
-    Vehicle.Exterior.AirTemperature, and Vehicle.Body.Raindetection.Intensity,
-    optionally combined with camera-based visibility classification.
-    The camera-based classification method is implementation specific.
-    NONE indicates normal visibility conditions.
-    RISK indicates elevated risk of visibility loss (e.g., heavy snow
-    onset, blowing snow conditions developing).
-    DETECTED indicates active whiteout conditions are affecting the vehicle.
-    UNKNOWN shall be used when the system cannot assess visibility-loss
-    risk (e.g., relevant sensors unavailable or input data confidence
-    below threshold).
+    Derived safety assessment layered on the Exterior observational signals
+    Vehicle.Exterior.VisibilityCondition (dominant cause of reduced
+    visibility) and Vehicle.Exterior.VisibilityDistance (quantitative range).
+    VisibilityImpairment is cause-agnostic and reports only the derived,
+    speed-relative safety risk on top of those signals; the cause itself
+    (snow, fog, etc.) is carried by VisibilityCondition.
+    May be derived from Vehicle.Exterior.VisibilityCondition and
+    Vehicle.Exterior.VisibilityDistance, optionally combined with vehicle
+    speed and stopping-distance context.
+    NONE indicates visibility is adequate for current driving conditions.
+    RISK indicates visibility is degrading toward a level that materially
+    raises driving risk for the current speed.
+    DETECTED indicates visibility impairment severe enough to require driver
+    action is active.
+    UNKNOWN shall be used when the system cannot assess visibility impairment.
     Criteria for each state may be OEM specific.
     Primary consumers: driver-warning systems, navigation systems
-    (re-routing on whiteout), and emergency dispatch systems
-    (incident-response prioritization).
+    (re-routing on impaired visibility), and emergency dispatch systems.
     Related to VSS issue #877 (Connected Safety signals).
 
 RoadIcingState:
@@ -88,29 +91,21 @@ RoadIcingState:
   ]
   description: Indicates whether the vehicle is currently at risk of icing-related loss of control or has detected such conditions affecting traction.
   comment: >
-    Derived assessment distinct from Vehicle.Exterior.RoadSurfaceCondition.
-    RoadSurfaceCondition reports observed surface state (DRY/WET/SNOW/ICE/...);
-    RoadIcingState reports the derived risk of icing-related loss of control.
-    RoadIcingState.RISK can be elevated even when RoadSurfaceCondition reports
-    DRY (black-ice, freezing rain onset), and RoadIcingState.NONE can hold even
-    when RoadSurfaceCondition reports SNOW (low-speed packed-snow with adequate
-    winter-tire grip).
+    Derived assessment distinct from Vehicle.Exterior.RoadSurfaceCondition,
+    which reports observed surface state; RoadIcingState reports the derived
+    risk of icing-related loss of control. RISK can be elevated even when
+    RoadSurfaceCondition reports DRY (black ice, freezing-rain onset), and
+    NONE can hold even when it reports SNOW (low-speed packed snow with
+    adequate winter-tire grip).
     May be derived from Vehicle.Exterior.RoadSurfaceCondition,
     Vehicle.Exterior.AirTemperature, Vehicle.ADAS.ESC.RoadFriction.MostProbable,
-    and dew-point / road-surface-temperature differential signals.
+    and road-surface-temperature signals.
     NONE indicates no elevated icing risk.
     RISK indicates conditions favor ice formation or onset of icing-related
     traction loss.
-    DETECTED indicates active icing-related loss of control has been observed
-    and requires corroborating environmental signal (low ambient temperature,
-    prior wet/snow observation) in addition to friction-loss observation; ESC
-    intervention alone is insufficient evidence absent environmental
-    corroboration.
-    UNKNOWN shall be used when the system cannot assess icing risk
-    (e.g., relevant sensors unavailable or input data confidence below
-    threshold).
+    DETECTED indicates active icing-related loss of control is occurring.
+    UNKNOWN shall be used when the system cannot assess icing risk.
     Criteria for each state may be OEM specific.
-    Primary consumers: driver-warning systems, ADAS interventions
-    (slip-rate-aware torque shaping), and navigation systems
-    (re-routing away from elevated-risk segments).
+    Primary consumers: driver-warning systems, ADAS interventions, and
+    navigation systems (re-routing away from elevated-risk segments).
     Related to VSS issue #877 (Connected Safety signals).

--- a/spec/Safety/Safety.vspec
+++ b/spec/Safety/Safety.vspec
@@ -48,3 +48,69 @@ Rollover:
     Criteria for each state may be OEM specific.
     Primary consumers: emergency dispatch and first responder systems.
     Related to VSS issue #877 (Connected Safety signals).
+
+WhiteoutRisk:
+  datatype: string
+  type: sensor
+  allowed: [
+    'UNKNOWN',
+    'NONE',
+    'RISK',
+    'DETECTED'
+  ]
+  description: Indicates whether the vehicle is currently affected by whiteout conditions (severe visibility loss from heavy snow, blowing snow, or fog) or is at risk of entering such conditions.
+  comment: >
+    May be derived from Vehicle.Exterior.RoadSurfaceCondition,
+    Vehicle.Exterior.AirTemperature, Vehicle.Body.Raindetection.Intensity,
+    Vehicle.ADAS.* visibility-class signals, and optional camera-based
+    visibility classification.
+    NONE indicates normal visibility conditions.
+    RISK indicates elevated risk of visibility loss (e.g., heavy snow
+    onset, blowing snow conditions developing).
+    DETECTED indicates active whiteout conditions are affecting the vehicle.
+    UNKNOWN shall be used when the system cannot assess visibility-loss
+    risk (e.g., relevant sensors unavailable or input data confidence
+    below threshold).
+    Criteria for each state may be OEM specific.
+    Primary consumers: driver-warning systems, navigation systems
+    (re-routing on whiteout), and emergency dispatch systems
+    (incident-response prioritization).
+    Related to VSS issue #877 (Connected Safety signals).
+
+RoadIcingState:
+  datatype: string
+  type: sensor
+  allowed: [
+    'UNKNOWN',
+    'NONE',
+    'RISK',
+    'DETECTED'
+  ]
+  description: Indicates whether the vehicle is currently at risk of icing-related loss of control or has detected such conditions affecting traction.
+  comment: >
+    Derived assessment distinct from Vehicle.Exterior.RoadSurfaceCondition.
+    RoadSurfaceCondition reports observed surface state (DRY/WET/SNOW/ICE/...);
+    RoadIcingState reports the derived risk of icing-related loss of control.
+    RoadIcingState.RISK can be elevated even when RoadSurfaceCondition reports
+    DRY (black-ice, freezing rain onset), and RoadIcingState.NONE can hold even
+    when RoadSurfaceCondition reports SNOW (low-speed packed-snow with adequate
+    winter-tire grip).
+    May be derived from Vehicle.Exterior.RoadSurfaceCondition,
+    Vehicle.Exterior.AirTemperature, Vehicle.ADAS.ESC.RoadFriction.MostProbable,
+    and dew-point / road-surface-temperature differential signals.
+    NONE indicates no elevated icing risk.
+    RISK indicates conditions favor ice formation or onset of icing-related
+    traction loss.
+    DETECTED indicates active icing-related loss of control has been observed
+    and requires corroborating environmental signal (low ambient temperature,
+    prior wet/snow observation) in addition to friction-loss observation; ESC
+    intervention alone is insufficient evidence absent environmental
+    corroboration.
+    UNKNOWN shall be used when the system cannot assess icing risk
+    (e.g., relevant sensors unavailable or input data confidence below
+    threshold).
+    Criteria for each state may be OEM specific.
+    Primary consumers: driver-warning systems, ADAS interventions
+    (slip-rate-aware torque shaping), and navigation systems
+    (re-routing away from elevated-risk segments).
+    Related to VSS issue #877 (Connected Safety signals).


### PR DESCRIPTION
## Summary

Adds two derived-assessment signals to `Vehicle.Safety.*`:

- `Vehicle.Safety.Whiteout` — assessment of visibility-loss risk in heavy snow / blowing snow / fog conditions
- `Vehicle.Safety.RoadIcingState` — assessment of icing-related loss-of-control risk, distinct from observed surface state

Both signals follow the `Rollover` precedent (#894) in the `Vehicle.Safety` branch: 4-value enum `[UNKNOWN, NONE, RISK, DETECTED]`, derived from sensor-fusion inputs, primary consumers including emergency dispatch and ADAS safety systems.

## Motivation

Extends the `Vehicle.Safety` branch (#894 by @vje013) per the architectural direction articulated by @erikbosch in #877:

> "a `Vehicle.Safety` branch with derived/smart values like `IsFire`, `IsSubmersed` or similar would look nice"

These two signals address driver-life-impact scenarios in snow / icing conditions — vocabulary that allows safety systems and driver-warning systems to act on derived risk rather than only observed surface state.

Both signals are suitable as Semantic Reasoning inputs within the COVESA Central Data Service Playground (CDSP), aligning with the integration direction raised in #877 by @slawr.

## Boundary against existing signals

- **`Vehicle.Exterior.RoadSurfaceCondition`** (#892, merged 2026-05-05) reports observed surface state (DRY/WET/SNOW/ICE/SLUSH/...). `RoadIcingState` reports a derived risk assessment that is bidirectionally distinct: `RoadIcingState.RISK` can be elevated even when `RoadSurfaceCondition` reports `DRY` (black-ice, freezing rain onset), and `RoadIcingState.NONE` can hold even when `RoadSurfaceCondition` reports `SNOW` (low-speed packed-snow with adequate winter-tire grip). The two signals coexist non-redundantly: RoadSurfaceCondition is one input among several to RoadIcingState's risk assessment.
- **`Vehicle.Safety.Rollover`** (#894, merged 2026-05-05) provides the precedent enum shape and comment pattern that both new signals follow.

## VSS issue link

Related to VSS issue #877 (Connected Safety signals).

## Spec changes

- `spec/Safety/Safety.vspec`: +2 signals (Whiteout + RoadIcingState)

## Testing

- `make csv --strict` passes locally (91 VSpecs loaded; new signals appear in output)
- `make json` passes locally
- `make jsonschema` passes locally
- `pre-commit run` passes (trailing-whitespace + end-of-file-fixer + check-added-large-files)
- Enum value sets confirm syntactic validity per existing `Rollover` precedent

## Reviewers

cc @vje013 (`Vehicle.Safety` branch author, #894) — for `RoadSurfaceCondition` boundary semantics review
cc @erikbosch — per `Vehicle.Safety` derived-values architectural direction articulated in #877 (2026-04-08)
cc @paulboyes — for weather-class signal pattern context

