### PR TITLE
feat(chassis): add Tire.WinterStatus fitted winter-tire capability attribute

### DIFF
--- a/spec/Chassis/Wheel.vspec
+++ b/spec/Chassis/Wheel.vspec
@@ -74,6 +74,40 @@ Tire.AirTemperature:
   unit: Celsius
   description: Air temperature inside the tire in Celsius.
 
+Tire.WinterStatus:
+  datatype: string
+  type: attribute
+  allowed: [
+    'UNKNOWN',
+    'NON_WINTER',
+    'WINTER'
+  ]
+  default: 'UNKNOWN'
+  description: Winter (cold-weather / snow) capability class of the tire currently fitted to this wheel.
+  comment: >
+    Describes the cold-weather grip capability of the fitted tire, which is the
+    primary determinant of available traction on snow and ice. Modelled as an
+    attribute because it is a property of the mounted equipment that changes only
+    when tires are swapped, not a continuously varying measurement.
+    WINTER indicates a dedicated winter / snow tire (e.g. carrying the
+    three-peak-mountain-snowflake 3PMSF marking), designed for cold-weather rubber
+    compounds and tread patterns that retain grip below approximately 7 degrees
+    Celsius and on snow / ice.
+    NON_WINTER covers summer and all-season tires alike: neither is a dedicated
+    winter tire, and from a snow-traction standpoint both leave the vehicle with
+    materially reduced cold-weather grip. The summer-vs-all-season distinction is
+    a longevity / comfort property that does not change the snow-safety answer and
+    is therefore intentionally not split here.
+    UNKNOWN shall be used when the fitted-tire winter capability cannot be
+    determined (e.g. no tire-identification data available, or input confidence
+    below threshold).
+    Primary consumers: driver-warning systems and navigation systems that adapt
+    snow / mountain-pass routing and advisory thresholds to the grip the vehicle
+    actually has. Combined with per-wheel placement, allows detection of mismatched
+    or partially-fitted winter tire sets.
+    Criteria for each state may be OEM specific.
+    Related to VSS issue #877 (Connected Safety signals).
+
 #
 # Wheel signals
 #

--- a/spec/Chassis/Wheel.vspec
+++ b/spec/Chassis/Wheel.vspec
@@ -105,7 +105,8 @@ Tire.WinterStatus:
     snow / mountain-pass routing and advisory thresholds to the grip the vehicle
     actually has. Combined with per-wheel placement, allows detection of mismatched
     or partially-fitted winter tire sets.
-    Criteria for each state may be OEM specific.
+    Criteria for each state may be OEM-, market-, or jurisdiction-specific
+    (e.g. national winter-tire regulations differ).
     Related to VSS issue #877 (Connected Safety signals).
 
 #


### PR DESCRIPTION
## Summary

Adds `Tire.WinterStatus`, a per-wheel attribute reporting the winter (cold-weather / snow) capability class of the fitted tire, under the existing `Vehicle.Chassis.Axle.Row[N].Wheel.{Left,Right}.Tire` branch.

Allowed values: `UNKNOWN` (default), `NON_WINTER`, `WINTER`.

## Motivation

The fitted tire's winter capability is the primary determinant of available traction on snow and ice. Exposing it as a standard signal lets driver-warning and navigation systems adapt snow / mountain-pass advisories to the grip the vehicle actually has, rather than assuming it. Per-wheel placement also surfaces mismatched or partially-fitted winter-tire sets.

This is the second of a two-signal Connected-Safety set related to #877; the first (Vehicle.Safety derived risk signals) is in #906.

## Boundary against existing signals

`Tire.WinterStatus` is fitted-equipment class (an attribute, changes only on tire swap). It is distinct from live-condition sensors such as `Vehicle.Safety.RoadIcingState` (#906) and `Vehicle.ADAS.ESC.RoadFriction`, which report derived/measured live traction. WinterStatus reports installed capability; those report current conditions.

## Spec changes

`spec/Chassis/Wheel.vspec`: one new attribute `Tire.WinterStatus`.

## Testing

`make csv`, `make json`, `make jsonschema`, and `pre-commit` all pass (strict).

---
@erikbosch @vje013 @paulboyes — would appreciate your review when convenient. Companion to #906.