### PR TITLE
Add initial AUTOSAR to VSS mapping reference

### DIFF
--- a/contributions/autosar_vss_mapping.md
+++ b/contributions/autosar_vss_mapping.md
@@ -1,0 +1,12 @@
+| AUTOSAR Signal | Candidate VSS Signal |
+|----------------|----------------------|
+| VehSpd | Vehicle.Speed |
+| AvgVehSpd | Vehicle.AverageSpeed |
+| Latitude | Vehicle.CurrentLocation.Latitude |
+| Longitude | Vehicle.CurrentLocation.Longitude |
+| Odometer | Vehicle.Odometer |
+| SOC | Vehicle.Powertrain.TractionBattery.StateOfCharge.Current |
+| SteerWhlAng | Vehicle.MotionManagement.Steering.SteeringWheel.Angle |
+| VehYawRate | TBD |
+| AccPedPos | TBD |
+| BrakePedPos | TBD |


### PR DESCRIPTION
Title: Proposal: AUTOSAR ↔ VSS Signal Mapping Reference

Many automotive organizations use AUTOSAR naming conventions internally while adopting VSS as a common semantic vehicle data model.

I would like to contribute a reference mapping document between commonly used AUTOSAR signals and corresponding VSS signals.

The intent is to help:

* SDV architects
* Middleware developers
* Signal database engineers
* AUTOSAR migration projects

Initial mappings include:

* Vehicle.Speed
* Vehicle.AverageSpeed
* Vehicle.CurrentLocation.Latitude
* Vehicle.CurrentLocation.Longitude
* Vehicle.Powertrain.TractionBattery.StateOfCharge.Current
* Vehicle.MotionManagement.Steering.SteeringWheel.Angle

Before expanding the mapping set, I would appreciate guidance on:

1. Whether such a reference document would be valuable to the project.
2. Preferred location within the repository.
3. Expected format and maintenance approach.
