### PR TITLE
feat(exterior): add road conditions, visibility, and weather signals from SENSORIS v1.6

### DIFF
--- a/spec/Vehicle/Exterior.vspec
+++ b/spec/Vehicle/Exterior.vspec
@@ -53,3 +53,183 @@ RoadSurfaceCondition:
     UNKNOWN shall be used when the system cannot assess the road surface condition.
     Primary consumers: navigation and ADAS safety systems.
     Related to VSS issue #877 (Connected Safety signals).
+
+RoadSurfaceContaminant:
+  datatype: string
+  type: sensor
+  allowed: [
+    'UNKNOWN',
+    'NONE',
+    'MUD',
+    'CHIPPINGS',
+    'OIL',
+    'FUEL'
+  ]
+  description: Detected non-weather surface contaminant on the road beneath or ahead of the vehicle.
+  comment: >
+    Reports road surface contaminants that are distinct from weather-related
+    surface state (covered by Vehicle.Exterior.RoadSurfaceCondition) and
+    road obstruction objects (tree, rockfall, etc.).
+    NONE indicates no surface contaminant detected.
+    UNKNOWN shall be used when the system cannot assess surface contamination.
+    OIL and FUEL indicate liquid hydrocarbon contamination (slip hazard and
+    fire risk). CHIPPINGS indicates loose aggregate (tire damage risk,
+    reduced road holding).
+    Determination method is implementation specific.
+    Compliant with SENSORIS v1.6 RoadSurfaceCondition.TypeAndConfidence
+    and TPEG-TEC road surface condition taxonomy.
+    Related to VSS issue #877 (Connected Safety signals).
+
+RoadObstruction:
+  datatype: string
+  type: sensor
+  allowed: [
+    'UNKNOWN',
+    'NONE',
+    'TREE',
+    'AVALANCHE',
+    'ROCKFALLS',
+    'SHED_LOAD',
+    'LAND_SLIP',
+    'ANIMAL',
+    'ANIMAL_LARGE',
+    'ANIMAL_HERD',
+    'FLOODING'
+  ]
+  description: Type of road obstruction detected ahead of the vehicle.
+  comment: >
+    Reports the category of road obstruction detected by the vehicle's
+    perception systems. NONE indicates no obstruction detected.
+    UNKNOWN shall be used when obstruction type cannot be classified.
+    ANIMAL covers small animals (cat, dog); ANIMAL_LARGE covers large animals
+    (deer, horse, livestock); ANIMAL_HERD covers groups of animals on road.
+    FLOODING indicates standing water sufficient to obstruct passage (distinct
+    from WET surface state in Vehicle.Exterior.RoadSurfaceCondition).
+    SHED_LOAD covers cargo fallen from another vehicle.
+    Determination method is implementation specific (camera, radar, lidar).
+    Compliant with SENSORIS v1.6 RoadObstructionCondition.TypeAndConfidence
+    and TPEG-TEC road obstruction taxonomy.
+    Primary consumers: navigation systems (dynamic re-routing), ADAS safety
+    systems, and emergency dispatch systems.
+    Related to VSS issue #877 (Connected Safety signals).
+
+VisibilityCondition:
+  datatype: string
+  type: sensor
+  allowed: [
+    'UNKNOWN',
+    'CLEAR',
+    'MIST',
+    'LOW_FOG',
+    'LOW_HEAVY_RAIN',
+    'LOW_HEAVY_SNOW',
+    'LOW_SMOKE',
+    'LOW_SUN_GLARE'
+  ]
+  description: Assessed visibility condition outside the vehicle.
+  comment: >
+    Reports the dominant cause of reduced visibility. CLEAR indicates no
+    significant visibility reduction. LOW_* values indicate conditions that
+    materially reduce driver or sensor visibility range.
+    UNKNOWN shall be used when visibility condition cannot be assessed
+    (e.g., camera unavailable or confidence below threshold).
+    Determination method is implementation specific. May be derived from
+    camera-based classification, Vehicle.Body.Raindetection.Intensity,
+    Vehicle.Exterior.AirTemperature, and Vehicle.Body.Windshield.Wiping.Mode.
+    Complements Vehicle.Exterior.VisibilityDistance for quantitative range.
+    Related to SENSORIS v1.6 VisibilityCondition.TypeAndConfidence.
+    Primary consumers: ADAS systems, navigation (dynamic re-routing), and
+    emergency dispatch systems.
+    Related to VSS issue #877 (Connected Safety signals).
+
+VisibilityDistance:
+  datatype: float
+  type: sensor
+  unit: m
+  min: 0
+  description: Estimated visible distance ahead of the vehicle in current conditions.
+  comment: >
+    Forward visibility range in meters as assessed by the vehicle's sensing
+    systems. 0 indicates near-zero visibility. Value may be limited by sensor
+    range rather than actual atmospheric visibility; see VisibilityCondition
+    for the qualitative assessment.
+    Determination method is implementation specific. May be derived from
+    camera-based visibility estimation, lidar range reduction, or
+    radar clutter analysis.
+    Related to SENSORIS v1.6 VisibilityCondition.visible_distance_and_accuracy.
+    Related to VSS issue #877 (Connected Safety signals).
+
+PrecipitationType:
+  datatype: string
+  type: sensor
+  allowed: [
+    'UNKNOWN',
+    'NONE',
+    'RAIN',
+    'MIXED_RAIN_SNOW',
+    'SNOW',
+    'HAIL'
+  ]
+  description: Type of precipitation currently detected outside the vehicle.
+  comment: >
+    Discriminates precipitation type from Vehicle.Body.Raindetection.Intensity,
+    which reports intensity for rain only. NONE indicates no precipitation
+    detected. HAIL includes sleet and freezing rain as a precipitation
+    type (distinct from black ice formation on the road surface, which is
+    reported by Vehicle.Safety.RoadIcingState when available).
+    UNKNOWN shall be used when precipitation type cannot be assessed.
+    Determination method is implementation specific.
+    Related to SENSORIS v1.6 Precipitation.TypeAndConfidence.
+    Related to VSS issue #877 (Connected Safety signals).
+
+PrecipitationIntensity:
+  datatype: float
+  type: sensor
+  unit: mm/h
+  min: 0
+  description: Precipitation intensity in millimeters per hour.
+  comment: >
+    Provides an absolute intensity measurement complementing
+    Vehicle.Body.Raindetection.Intensity (which is a relative 0-100 percent
+    scale). Applies to all precipitation types reported by
+    Vehicle.Exterior.PrecipitationType; value is 0 when PrecipitationType
+    is NONE. Measurement method is sensor specific.
+    Related to SENSORIS v1.6 Precipitation.absolute_intensity_and_accuracy.
+    Related to VSS issue #877 (Connected Safety signals).
+
+AirPressure:
+  datatype: float
+  type: sensor
+  unit: hPa
+  description: Atmospheric air pressure outside the vehicle.
+  comment: >
+    Static ambient air pressure measured by the vehicle's barometric sensor.
+    May be used for altitude estimation, weather trend detection, and HVAC
+    pressurization management.
+    Related to SENSORIS v1.6 AtmosphereCondition.static_air_pressure.
+
+WindSpeed:
+  datatype: float
+  type: sensor
+  unit: m/s
+  min: 0
+  description: Wind speed outside the vehicle.
+  comment: >
+    Measured or estimated wind speed in meters per second.
+    May be derived from anemometer sensors, aerodynamic load estimation,
+    or external weather service input.
+    Related to SENSORIS v1.6 WindCondition.speed_and_accuracy.
+
+WindDirection:
+  datatype: float
+  type: sensor
+  unit: degrees
+  min: 0
+  max: 360
+  description: Wind direction in degrees (meteorological convention, 0 = North, 90 = East).
+  comment: >
+    Wind direction from which wind is blowing, using meteorological convention
+    (0 = from North, 90 = from East, 180 = from South, 270 = from West).
+    Only meaningful when WindSpeed is above a minimum threshold; value when
+    WindSpeed is near 0 is implementation specific.
+    Related to SENSORIS v1.6 WindCondition.direction_and_accuracy.

--- a/spec/Vehicle/Exterior.vspec
+++ b/spec/Vehicle/Exterior.vspec
@@ -205,7 +205,7 @@ WindSpeed:
   type: sensor
   unit: m/s
   min: 0
-  description: Wind speed outside the vehicle.
+  description: Surface wind speed outside the vehicle.
   comment: >
     Measured or estimated wind speed in meters per second.
     May be derived from anemometer sensors, aerodynamic load estimation,

--- a/spec/Vehicle/Exterior.vspec
+++ b/spec/Vehicle/Exterior.vspec
@@ -34,7 +34,7 @@ LightIntensity:
 RoadSurfaceCondition:
   datatype: string
   type: sensor
-  allowed: [
+  enum: [
     'UNKNOWN',
     'DRY',
     'WET',
@@ -57,7 +57,7 @@ RoadSurfaceCondition:
 RoadSurfaceContaminant:
   datatype: string
   type: sensor
-  allowed: [
+  enum: [
     'UNKNOWN',
     'NONE',
     'MUD',
@@ -67,23 +67,23 @@ RoadSurfaceContaminant:
   ]
   description: Detected non-weather surface contaminant on the road beneath or ahead of the vehicle.
   comment: >
-    Reports road surface contaminants that are distinct from weather-related
-    surface state (covered by Vehicle.Exterior.RoadSurfaceCondition) and
-    road obstruction objects (tree, rockfall, etc.).
-    NONE indicates no surface contaminant detected.
-    UNKNOWN shall be used when the system cannot assess surface contamination.
-    OIL and FUEL indicate liquid hydrocarbon contamination (slip hazard and
-    fire risk). CHIPPINGS indicates loose aggregate (tire damage risk,
-    reduced road holding).
-    Determination method is implementation specific.
-    Compliant with SENSORIS v1.6 RoadSurfaceCondition.TypeAndConfidence
-    and TPEG-TEC road surface condition taxonomy.
-    Related to VSS issue #877 (Connected Safety signals).
+    Reports road surface contaminants that are distinct from
+    weather-related surface state (covered by
+    Vehicle.Exterior.RoadSurfaceCondition) and road obstruction
+    objects (tree, rockfall, etc.). UNKNOWN shall be used when the
+    system cannot assess surface contamination. NONE indicates no
+    surface contaminant detected. MUD indicates wet dirt. CHIPPINGS
+    indicates loose aggregate (tire damage risk, reduced road
+    holding). OIL and FUEL indicate liquid hydrocarbon contamination
+    (slip hazard and fire risk).  Determination method is
+    implementation specific.  Compliant with SENSORIS v1.6
+    RoadSurfaceCondition.TypeAndConfidence and TPEG-TEC road surface
+    condition taxonomy.
 
 RoadObstruction:
   datatype: string
   type: sensor
-  allowed: [
+  enum: [
     'UNKNOWN',
     'NONE',
     'TREE',
@@ -99,24 +99,25 @@ RoadObstruction:
   description: Type of road obstruction detected ahead of the vehicle.
   comment: >
     Reports the category of road obstruction detected by the vehicle's
-    perception systems. NONE indicates no obstruction detected.
-    UNKNOWN shall be used when obstruction type cannot be classified.
-    ANIMAL covers small animals (cat, dog); ANIMAL_LARGE covers large animals
-    (deer, horse, livestock); ANIMAL_HERD covers groups of animals on road.
-    FLOODING indicates standing water sufficient to obstruct passage (distinct
-    from WET surface state in Vehicle.Exterior.RoadSurfaceCondition).
-    SHED_LOAD covers cargo fallen from another vehicle.
-    Determination method is implementation specific (camera, radar, lidar).
-    Compliant with SENSORIS v1.6 RoadObstructionCondition.TypeAndConfidence
-    and TPEG-TEC road obstruction taxonomy.
-    Primary consumers: navigation systems (dynamic re-routing), ADAS safety
-    systems, and emergency dispatch systems.
-    Related to VSS issue #877 (Connected Safety signals).
+    perception systems. UNKNOWN shall be used when obstruction type
+    cannot be classified. NONE indicates no obstruction detected.
+    SHED_LOAD covers cargo fallen from another vehicle. LAND_SLIP or
+    landslide is ground material that has slid down slope into
+    road. ANIMAL covers small animals (cat, dog); ANIMAL_LARGE covers
+    large animals (deer, horse, livestock); ANIMAL_HERD covers groups
+    of animals on road.  FLOODING indicates standing water sufficient
+    to obstruct passage (distinct from WET surface state in
+    Vehicle.Exterior.RoadSurfaceCondition). Determination method is
+    implementation specific (camera, radar, lidar). Compliant with
+    SENSORIS v1.6 RoadObstructionCondition.TypeAndConfidence and
+    TPEG-TEC road obstruction taxonomy.  Primary consumers: navigation
+    systems (dynamic re-routing), ADAS safety systems, and emergency
+    dispatch systems.
 
 VisibilityCondition:
   datatype: string
   type: sensor
-  allowed: [
+  enum: [
     'UNKNOWN',
     'CLEAR',
     'MIST',
@@ -128,19 +129,19 @@ VisibilityCondition:
   ]
   description: Assessed visibility condition outside the vehicle.
   comment: >
-    Reports the dominant cause of reduced visibility. CLEAR indicates no
-    significant visibility reduction. LOW_* values indicate conditions that
-    materially reduce driver or sensor visibility range.
-    UNKNOWN shall be used when visibility condition cannot be assessed
-    (e.g., camera unavailable or confidence below threshold).
-    Determination method is implementation specific. May be derived from
-    camera-based classification, Vehicle.Body.Raindetection.Intensity,
-    Vehicle.Exterior.AirTemperature, and Vehicle.Body.Windshield.Wiping.Mode.
-    Complements Vehicle.Exterior.VisibilityDistance for quantitative range.
-    Related to SENSORIS v1.6 VisibilityCondition.TypeAndConfidence.
-    Primary consumers: ADAS systems, navigation (dynamic re-routing), and
-    emergency dispatch systems.
-    Related to VSS issue #877 (Connected Safety signals).
+    Reports the dominant cause of reduced visibility.  UNKNOWN shall
+    be used when visibility condition cannot be assessed (e.g., camera
+    unavailable or confidence below threshold).  CLEAR indicates no
+    significant visibility reduction. LOW_* values indicate conditions
+    that materially reduce driver or sensor visibility range.
+    Determination method is implementation specific. May be derived
+    from camera-based classification,
+    Vehicle.Body.Raindetection.Intensity,
+    Vehicle.Exterior.AirTemperature, and
+    Vehicle.Body.Windshield.Wiping.Mode.  Complements
+    Vehicle.Exterior.VisibilityDistance for quantitative range.
+    Primary consumers: ADAS systems, navigation (dynamic re-routing),
+    and emergency dispatch systems.
 
 VisibilityDistance:
   datatype: float
@@ -156,13 +157,11 @@ VisibilityDistance:
     Determination method is implementation specific. May be derived from
     camera-based visibility estimation, lidar range reduction, or
     radar clutter analysis.
-    Related to SENSORIS v1.6 VisibilityCondition.visible_distance_and_accuracy.
-    Related to VSS issue #877 (Connected Safety signals).
 
 PrecipitationType:
   datatype: string
   type: sensor
-  allowed: [
+  enum: [
     'UNKNOWN',
     'NONE',
     'RAIN',
@@ -172,15 +171,14 @@ PrecipitationType:
   ]
   description: Type of precipitation currently detected outside the vehicle.
   comment: >
-    Discriminates precipitation type from Vehicle.Body.Raindetection.Intensity,
-    which reports intensity for rain only. NONE indicates no precipitation
-    detected. HAIL includes sleet and freezing rain as a precipitation
-    type (distinct from black ice formation on the road surface, which is
-    reported by Vehicle.Safety.RoadIcingState when available).
-    UNKNOWN shall be used when precipitation type cannot be assessed.
+    Discriminates precipitation type from
+    Vehicle.Body.Raindetection.Intensity, which reports intensity for
+    rain only. UNKNOWN shall be used when precipitation type cannot
+    be assessed. NONE indicates no precipitation detected. HAIL
+    includes sleet and freezing rain as a precipitation type (distinct
+    from black ice formation on the road surface, which is reported by
+    Vehicle.Safety.RoadIcingState when available).
     Determination method is implementation specific.
-    Related to SENSORIS v1.6 Precipitation.TypeAndConfidence.
-    Related to VSS issue #877 (Connected Safety signals).
 
 PrecipitationIntensity:
   datatype: float
@@ -194,8 +192,6 @@ PrecipitationIntensity:
     scale). Applies to all precipitation types reported by
     Vehicle.Exterior.PrecipitationType; value is 0 when PrecipitationType
     is NONE. Measurement method is sensor specific.
-    Related to SENSORIS v1.6 Precipitation.absolute_intensity_and_accuracy.
-    Related to VSS issue #877 (Connected Safety signals).
 
 AirPressure:
   datatype: float
@@ -218,7 +214,6 @@ WindSpeed:
     Measured or estimated wind speed in meters per second.
     May be derived from anemometer sensors, aerodynamic load estimation,
     or external weather service input.
-    Related to SENSORIS v1.6 WindCondition.speed_and_accuracy.
 
 WindDirection:
   datatype: float
@@ -232,4 +227,4 @@ WindDirection:
     (0 = from North, 90 = from East, 180 = from South, 270 = from West).
     Only meaningful when WindSpeed is above a minimum threshold; value when
     WindSpeed is near 0 is implementation specific.
-    Related to SENSORIS v1.6 WindCondition.direction_and_accuracy.
+

--- a/spec/Vehicle/Exterior.vspec
+++ b/spec/Vehicle/Exterior.vspec
@@ -32,113 +32,109 @@ LightIntensity:
   comment: Mapping to physical units and calculation method is sensor specific.
 
 RoadSurfaceCondition:
-  datatype: string
+  datatype: uint8
   type: sensor
-  enum: [
-    'UNKNOWN',
-    'DRY',
-    'WET',
-    'SNOW',
-    'ICE',
-    'SLUSH',
-    'WET_ICE',
-    'LOOSE_GRAVEL'
-  ]
+  enum:
+    UNKNOWN: 0
+    DRY: 1
+    WET: 2
+    SNOW: 3
+    ICE: 4
+    SLUSH: 5
+    WET_ICE: 6
+    LOOSE_GRAVEL: 7
   description: Assessed condition of the road surface beneath or ahead of the vehicle.
   comment: >
     Determination method is implementation specific. May be derived from
     sensor fusion of Vehicle.ADAS.ESC.RoadFriction.MostProbable,
     Vehicle.Exterior.AirTemperature, Vehicle.Body.Raindetection.Intensity,
     and optional camera-based road surface classification.
-    UNKNOWN shall be used when the system cannot assess the road surface condition.
+    UNKNOWN (0) shall be used when the system cannot assess the road surface condition.
     Primary consumers: navigation and ADAS safety systems.
     Related to VSS issue #877 (Connected Safety signals).
 
 RoadSurfaceContaminant:
-  datatype: string
+  datatype: uint8
   type: sensor
-  enum: [
-    'UNKNOWN',
-    'NONE',
-    'MUD',
-    'CHIPPINGS',
-    'OIL',
-    'FUEL'
-  ]
+  enum:
+    UNKNOWN: 0
+    MUD: 1
+    CHIPPINGS: 2
+    OIL: 3
+    FUEL: 4
+    NONE: 5
   description: Detected non-weather surface contaminant on the road beneath or ahead of the vehicle.
   comment: >
     Reports road surface contaminants that are distinct from
     weather-related surface state (covered by
     Vehicle.Exterior.RoadSurfaceCondition) and road obstruction
-    objects (tree, rockfall, etc.). UNKNOWN shall be used when the
-    system cannot assess surface contamination. NONE indicates no
-    surface contaminant detected. MUD indicates wet dirt. CHIPPINGS
-    indicates loose aggregate (tire damage risk, reduced road
-    holding). OIL and FUEL indicate liquid hydrocarbon contamination
-    (slip hazard and fire risk).  Determination method is
-    implementation specific.  Compliant with SENSORIS v1.6
-    RoadSurfaceCondition.TypeAndConfidence and TPEG-TEC road surface
-    condition taxonomy.
+    objects (tree, rockfall, etc.). UNKNOWN (0) shall be used when the
+    system cannot assess surface contamination. NONE (5) indicates no
+    surface contaminant detected. MUD (1) indicates wet dirt. CHIPPINGS
+    (2) indicates loose aggregate (tire damage risk, reduced road
+    holding). OIL (3) and FUEL (4) indicate liquid hydrocarbon
+    contamination (slip hazard and fire risk). Values 1-4 are aligned
+    with SENSORIS v1.6 RoadSurfaceCondition.TypeAndConfidence.
+    Determination method is implementation specific.
 
 RoadObstruction:
-  datatype: string
+  datatype: uint8
   type: sensor
-  enum: [
-    'UNKNOWN',
-    'NONE',
-    'TREE',
-    'AVALANCHE',
-    'ROCKFALLS',
-    'SHED_LOAD',
-    'LAND_SLIP',
-    'ANIMAL',
-    'ANIMAL_LARGE',
-    'ANIMAL_HERD',
-    'FLOODING'
-  ]
+  enum:
+    UNKNOWN: 0
+    TREE: 1
+    AVALANCHE: 2
+    ROCKFALLS: 3
+    SHED_LOAD: 4
+    LAND_SLIP: 5
+    ANIMAL: 6
+    ANIMAL_LARGE: 7
+    ANIMAL_HERD: 8
+    NONE: 9
+    FLOODING: 10
   description: Type of road obstruction detected ahead of the vehicle.
   comment: >
     Reports the category of road obstruction detected by the vehicle's
-    perception systems. UNKNOWN shall be used when obstruction type
-    cannot be classified. NONE indicates no obstruction detected.
-    SHED_LOAD covers cargo fallen from another vehicle. LAND_SLIP or
-    landslide is ground material that has slid down slope into
-    road. ANIMAL covers small animals (cat, dog); ANIMAL_LARGE covers
-    large animals (deer, horse, livestock); ANIMAL_HERD covers groups
-    of animals on road.  FLOODING indicates standing water sufficient
+    perception systems. UNKNOWN (0) shall be used when obstruction type
+    cannot be classified. NONE (9) indicates no obstruction detected.
+    SHED_LOAD (4) covers cargo fallen from another vehicle. LAND_SLIP (5)
+    or landslide is ground material that has slid down slope into road.
+    ANIMAL (6) covers small animals (cat, dog); ANIMAL_LARGE (7) covers
+    large animals (deer, horse, livestock); ANIMAL_HERD (8) covers groups
+    of animals on road. FLOODING (10) indicates standing water sufficient
     to obstruct passage (distinct from WET surface state in
-    Vehicle.Exterior.RoadSurfaceCondition). Determination method is
-    implementation specific (camera, radar, lidar). Compliant with
+    Vehicle.Exterior.RoadSurfaceCondition). Values 1-8 are aligned with
     SENSORIS v1.6 RoadObstructionCondition.TypeAndConfidence and
-    TPEG-TEC road obstruction taxonomy.  Primary consumers: navigation
-    systems (dynamic re-routing), ADAS safety systems, and emergency
-    dispatch systems.
+    TPEG-TEC road obstruction taxonomy. Determination method is
+    implementation specific (camera, radar, lidar). Primary consumers:
+    navigation systems (dynamic re-routing), ADAS safety systems, and
+    emergency dispatch systems.
 
 VisibilityCondition:
-  datatype: string
+  datatype: uint8
   type: sensor
-  enum: [
-    'UNKNOWN',
-    'CLEAR',
-    'MIST',
-    'LOW_FOG',
-    'LOW_HEAVY_RAIN',
-    'LOW_HEAVY_SNOW',
-    'LOW_SMOKE',
-    'LOW_SUN_GLARE'
-  ]
+  enum:
+    UNKNOWN: 0
+    CLEAR: 1
+    MIST: 2
+    LOW_HEAVY_RAIN: 3
+    LOW_HEAVY_SNOW: 4
+    LOW_SMOKE: 5
+    LOW_FOG: 6
+    LOW_SUN_GLARE: 7
   description: Assessed visibility condition outside the vehicle.
   comment: >
-    Reports the dominant cause of reduced visibility.  UNKNOWN shall
+    Reports the dominant cause of reduced visibility. UNKNOWN (0) shall
     be used when visibility condition cannot be assessed (e.g., camera
-    unavailable or confidence below threshold).  CLEAR indicates no
+    unavailable or confidence below threshold). CLEAR (1) indicates no
     significant visibility reduction. LOW_* values indicate conditions
-    that materially reduce driver or sensor visibility range.
+    that materially reduce driver or sensor visibility range. Values are
+    aligned with SENSORIS v1.6 VisibilityCondition.TypeAndConfidence.
     Determination method is implementation specific. May be derived
     from camera-based classification,
     Vehicle.Body.Raindetection.Intensity,
     Vehicle.Exterior.AirTemperature, and
-    Vehicle.Body.Windshield.Wiping.Mode.  Complements
+    Vehicle.Body.Windshield.Wiping.Mode. Complements
     Vehicle.Exterior.VisibilityDistance for quantitative range.
     Primary consumers: ADAS systems, navigation (dynamic re-routing),
     and emergency dispatch systems.
@@ -159,25 +155,25 @@ VisibilityDistance:
     radar clutter analysis.
 
 PrecipitationType:
-  datatype: string
+  datatype: uint8
   type: sensor
-  enum: [
-    'UNKNOWN',
-    'NONE',
-    'RAIN',
-    'MIXED_RAIN_SNOW',
-    'SNOW',
-    'HAIL'
-  ]
+  enum:
+    UNKNOWN: 0
+    NONE: 1
+    RAIN: 2
+    MIXED_RAIN_SNOW: 3
+    SNOW: 4
+    HAIL: 5
   description: Type of precipitation currently detected outside the vehicle.
   comment: >
     Discriminates precipitation type from
     Vehicle.Body.Raindetection.Intensity, which reports intensity for
-    rain only. UNKNOWN shall be used when precipitation type cannot
-    be assessed. NONE indicates no precipitation detected. HAIL
+    rain only. UNKNOWN (0) shall be used when precipitation type cannot
+    be assessed. NONE (1) indicates no precipitation detected. HAIL (5)
     includes sleet and freezing rain as a precipitation type (distinct
     from black ice formation on the road surface, which is reported by
-    Vehicle.Safety.RoadIcingState when available).
+    Vehicle.Safety.RoadIcingState when available). Values are aligned
+    with SENSORIS v1.6 Precipitation.TypeAndConfidence.
     Determination method is implementation specific.
 
 PrecipitationIntensity:
@@ -227,4 +223,3 @@ WindDirection:
     (0 = from North, 90 = from East, 180 = from South, 270 = from West).
     Only meaningful when WindSpeed is above a minimum threshold; value when
     WindSpeed is near 0 is implementation specific.
-

--- a/spec/quantities.yaml
+++ b/spec/quantities.yaml
@@ -81,3 +81,6 @@ resistance:
             quantity given by the quotient of voltage u and electric current i (IEC 80000-6:2022)
 illuminance:
   definition: Illuminance is the total luminous flux incident on a surface, per unit area, usually measured in Lux
+precipitation-rate:
+  definition: Depth of precipitation accumulated per unit time (ISO 80000-3:2019 applied to meteorology)
+  remark: Typically measured in millimeters per hour (mm/h). Applies to rain, snow (liquid equivalent), and mixed precipitation.

--- a/spec/units.yaml
+++ b/spec/units.yaml
@@ -462,15 +462,6 @@ l/h:
   qudt:
     unit: http://qudt.org/vocab/unit/L-PER-HR
     quantity-kind: https://qudt.org/vocab/quantitykind/VolumeFlowRate
-mm/h:
-  definition: Precipitation intensity measured in millimeters per hour
-  unit: millimeter per hour
-  quantity: precipitation-rate
-  allowed-datatypes: ['numeric']
-  qudt:
-    unit: http://qudt.org/vocab/unit/MilliM-PER-HR
-    quantity-kind: https://qudt.org/vocab/quantitykind/PrecipitationRate
-
 # Distance per volume
 
 mpg-us:
@@ -499,6 +490,17 @@ km/l:
   unit: kilometers per liter
   quantity: distance-per-volume
   allowed-datatypes: ['numeric']
+
+# Precipitation Rate
+
+mm/h:
+  definition: Precipitation intensity measured in millimeters per hour
+  unit: millimeter per hour
+  quantity: precipitation-rate
+  allowed-datatypes: ['numeric']
+  qudt:
+    unit: http://qudt.org/vocab/unit/MilliM-PER-HR
+    quantity-kind: https://qudt.org/vocab/quantitykind/PrecipitationRate
 
 # Force
 

--- a/spec/units.yaml
+++ b/spec/units.yaml
@@ -387,6 +387,14 @@ psi:
   qudt:
     unit: http://qudt.org/vocab/unit/PSI
     quantity-kind: https://qudt.org/vocab/quantitykind/VaporPressure
+hPa:
+  definition: Pressure measured in hectopascal
+  unit: hectopascal
+  quantity: pressure
+  allowed-datatypes: ['numeric']
+  qudt:
+    unit: http://qudt.org/vocab/unit/HectoPA
+    quantity-kind: https://qudt.org/vocab/quantitykind/AtmosphericPressure
 
 # Rating
 
@@ -454,6 +462,14 @@ l/h:
   qudt:
     unit: http://qudt.org/vocab/unit/L-PER-HR
     quantity-kind: https://qudt.org/vocab/quantitykind/VolumeFlowRate
+mm/h:
+  definition: Precipitation intensity measured in millimeters per hour
+  unit: millimeter per hour
+  quantity: precipitation-rate
+  allowed-datatypes: ['numeric']
+  qudt:
+    unit: http://qudt.org/vocab/unit/MilliM-PER-HR
+    quantity-kind: https://qudt.org/vocab/quantitykind/PrecipitationRate
 
 # Distance per volume
 


### PR DESCRIPTION
## Summary

This PR adds road condition, visibility, and weather sensing signals to \`Vehicle.Exterior\` based on a gap analysis comparing SENSORIS v1.6.0 against the current VSS. It also adds two missing units to \`spec/units.yaml\` and a new \`precipitation-rate\` quantity to \`spec/quantities.yaml\` required by the new signals.

Full gap analysis reference: [vss-sensoris-road-conditions-gap-analysis.md](https://github.com/COVESA/commercial-vehicles/blob/main/tmp/scratch/vss-sensoris-road-conditions-gap-analysis.md)

---

## Signals added

All enumerated signals use \`datatype: uint8\` with named integer constants per the syntax resolved in issue #873. Integer values are sourced directly from SENSORIS v1.6 proto enums where available; \`UNKNOWN=0\` is consistent across all signals.

### Priority 1 — Weather sensing (no new branch, extends existing \`Vehicle.Exterior\`)

| Signal | Datatype | Unit | SENSORIS source |
|--------|----------|------|-----------------|
| \`Vehicle.Exterior.VisibilityCondition\` | uint8 enum | — | \`weather.proto\` \`VisibilityCondition.TypeAndConfidence\` |
| \`Vehicle.Exterior.VisibilityDistance\` | float | m | \`weather.proto\` \`VisibilityCondition.visible_distance_and_accuracy\` |
| \`Vehicle.Exterior.PrecipitationType\` | uint8 enum | — | \`weather.proto\` \`Precipitation.TypeAndConfidence\` |
| \`Vehicle.Exterior.PrecipitationIntensity\` | float | mm/h | \`weather.proto\` \`Precipitation.absolute_intensity_and_accuracy\` |
| \`Vehicle.Exterior.AirPressure\` | float | hPa | \`weather.proto\` \`AtmosphereCondition.static_air_pressure\` |
| \`Vehicle.Exterior.WindSpeed\` | float | m/s | \`weather.proto\` \`WindCondition.speed_and_accuracy\` |
| \`Vehicle.Exterior.WindDirection\` | float | degrees | \`weather.proto\` \`WindCondition.direction_and_accuracy\` |

### Priority 2 — Road surface and obstruction (placement open for discussion)

| Signal | Datatype | SENSORIS source |
|--------|----------|-----------------|
| \`Vehicle.Exterior.RoadSurfaceContaminant\` | uint8 enum | \`traffic_events.proto\` \`RoadSurfaceCondition\` (MUD/CHIPPINGS/OIL/FUEL — non-weather contaminants, distinct from existing \`RoadSurfaceCondition\`) |
| \`Vehicle.Exterior.RoadObstruction\` | uint8 enum | \`traffic_events.proto\` \`RoadObstructionCondition\` (TREE/AVALANCHE/ROCKFALLS/SHED_LOAD/LAND_SLIP/ANIMAL/ANIMAL_LARGE/ANIMAL_HERD) |

### Enum integer values

All enumerated signals use integer constants aligned with SENSORIS v1.6 proto values (\`UNKNOWN_TYPE=0\` mapped to \`UNKNOWN=0\` throughout). Values added by VSS with no SENSORIS proto equivalent (\`NONE\`, \`FLOODING\`) are appended after the SENSORIS-defined range.

| Signal | Values |
|--------|--------|
| \`VisibilityCondition\` | \`UNKNOWN=0, CLEAR=1, MIST=2, LOW_HEAVY_RAIN=3, LOW_HEAVY_SNOW=4, LOW_SMOKE=5, LOW_FOG=6, LOW_SUN_GLARE=7\` |
| \`PrecipitationType\` | \`UNKNOWN=0, NONE=1, RAIN=2, MIXED_RAIN_SNOW=3, SNOW=4, HAIL=5\` |
| \`RoadSurfaceContaminant\` | \`UNKNOWN=0, MUD=1, CHIPPINGS=2, OIL=3, FUEL=4, NONE=5\` |
| \`RoadObstruction\` | \`UNKNOWN=0, TREE=1, AVALANCHE=2, ROCKFALLS=3, SHED_LOAD=4, LAND_SLIP=5, ANIMAL=6, ANIMAL_LARGE=7, ANIMAL_HERD=8, NONE=9, FLOODING=10\` |
| \`RoadSurfaceCondition\` (existing, updated for consistency) | \`UNKNOWN=0, DRY=1, WET=2, SNOW=3, ICE=4, SLUSH=5, WET_ICE=6, LOOSE_GRAVEL=7\` |

Note: \`NONE\` is placed after SENSORIS-defined values because SENSORIS omits it (proto3 field absence implies no detection) so it has no canonical integer. \`FLOODING\` in \`RoadObstruction\` is VSS-added; in SENSORIS it appears in \`RoadWeatherCondition\` (a different message) as value 6.

### Files changed in \`spec/units.yaml\` and \`spec/quantities.yaml\`

- \`hPa\` — hectopascal (pressure, for \`AirPressure\`)
- \`mm/h\` — millimeter per hour (precipitation rate, for \`PrecipitationIntensity\`); moved from \`# Volume flow rate\` to new \`# Precipitation Rate\` section
- \`precipitation-rate\` — new quantity added to \`spec/quantities.yaml\` (required by \`mm/h\` unit entry)

---

## Design notes and open questions for reviewers

**1. \`VisibilityCondition\` + PR #906 relationship**
\`Vehicle.Exterior.VisibilityCondition\` is the observational upstream signal for \`Vehicle.Safety.Whiteout\` (PR #906, open). \`LOW_HEAVY_SNOW\` in \`VisibilityCondition\` is a precursor condition to \`Whiteout = DETECTED\`. The two signals complement rather than duplicate each other: \`VisibilityCondition\` reports the physical cause; \`Whiteout\` reports the derived safety assessment. If PR #906 is reviewed first, please consider referencing \`Vehicle.Exterior.VisibilityCondition\` as an input in the \`Whiteout\` comment.

**2. \`RoadSurfaceContaminant\` vs. existing \`RoadSurfaceCondition\`**
SENSORIS uses two separate messages: \`RoadWeatherCondition\` (weather-caused states) and \`RoadSurfaceCondition\` (non-weather contaminants: MUD/CHIPPINGS/OIL/FUEL). VSS \`RoadSurfaceCondition\` (merged PR #892) covers weather states. \`RoadSurfaceContaminant\` fills the non-weather gap without overlap.

**3. Priority 2 signal placement**
\`RoadSurfaceContaminant\` and \`RoadObstruction\` are placed under \`Vehicle.Exterior\` here as perceived-environment signals — consistent with \`RoadSurfaceCondition\`. An alternative is a new \`Vehicle.Road\` branch (see Road.vspec scratch in commercial-vehicles repo). Feedback welcome; the signals can be moved in review or a follow-up PR.

**4. \`RoadObstruction\` vs. Object Detection branch**
SENSORIS \`RoadObstructionCondition\` lives in \`traffic_events.proto\` (not \`object_detection.proto\`). If VSS develops an Object Detection branch, \`RoadObstruction\` may warrant migration. For now it is placed in \`Vehicle.Exterior\` as a road-ahead condition.

**5. \`hPa\` quantity-kind**
Used \`AtmosphericPressure\` QUDT quantity-kind for \`hPa\`, distinct from \`VaporPressure\` used for \`Pa\`/\`kPa\`/\`mbar\`. Open to using \`Pressure\` if reviewers prefer uniformity.

**6. \`RoadSurfaceCondition\` enum update**
The merged \`RoadSurfaceCondition\` signal (PR #892) has been updated from flat string \`allowed\` to \`uint8\` enum with sequential values (0–7) for consistency with the new signals. There is no direct SENSORIS 1:1 integer mapping for this signal's value set.

**7. \`WindSpeed\` — surface wind, not vehicle-relative**
\`WindSpeed\` description clarified to *surface* wind speed: the ambient wind speed at ground level as measured or estimated by the vehicle's sensors. It is not a vector combination of vehicle speed and wind direction. Implementations deriving wind speed from aerodynamic load should account for vehicle heading to isolate the true surface wind component.

---

## Related

- VSS issue #873 — enum syntax resolution (drives \`uint8\` + integer constant approach used here)
- VSS issue #877 — Connected Safety signals (architectural thread)
- PR #892 (merged) — \`Vehicle.Exterior.RoadSurfaceCondition\`
- PR #894 (merged) — \`Vehicle.Safety.IsFire\`, \`IsSubmersed\`, \`Rollover\`
- PR #906 (open) — \`Vehicle.Safety.Whiteout\`, \`RoadIcingState\`
- SENSORIS v1.6.0 — \`weather.proto\`, \`traffic_events.proto\`, \`road_attribution.proto\`

cc @vje013 @erikbosch