### PR TITLE
Decoupling instance handling from model

### DIFF
--- a/docs-gen/content/rule_set/instances.md
+++ b/docs-gen/content/rule_set/instances.md
@@ -48,8 +48,9 @@ with two axles and two rows of seats. For other vehicles, see [recommendations o
 
 Typical naming conventions used in VSS standard catalog include:
 
-* When instances are defined by a range, e.g., `Position[m,n]`, VSS standard catalog uses `1` as start index for the first instance.
+* When instances are defined by a range, e.g., `Index[m,n]`, VSS standard catalog uses `1` as start index for the first instance.
 * The instance definition `Row[n,m]`, e.g., `Row[1,2]`, is used to indicate that there are multiple rows of the entity. Rows are counted from the front of the vehicle.
+* The instance definition `Position[n,m]`, e.g., `Position[1,3]`, is used to indicate that there are multiple positions of the entity (for a specific row). Posistions are counted from the left of the vehicle.
 * For items located on either left or right side of the vehicle VSS standard catalog uses two different conventions:
   * In some cases instances are defined relative to driver position, e.g., `["DriverSide", "PassengerSide"]`.
   * In other cases instances are defined based on physical position, e.g., `["Left","Right"]`.

--- a/spec/Cabin/Cabin.vspec
+++ b/spec/Cabin/Cabin.vspec
@@ -144,9 +144,6 @@ IsWindowChildLockEngaged:
 
 Seat:
   type: branch
-  instances:
-    - Row[1,2]
-    - ["DriverSide","Middle","PassengerSide"]
   description: All seats.
 #include Seat.vspec Seat
 

--- a/spec/Chassis/Chassis.vspec
+++ b/spec/Chassis/Chassis.vspec
@@ -22,8 +22,6 @@ Wheelbase:
 # Axle definition
 #
 Axle:
-  instances:
-    - Row[1,2]
   type: branch
   description: Axle signals
 
@@ -125,7 +123,6 @@ Axle.Torque:
 # Wheels on Axles
 #
 Axle.Wheel:
-  instances: ["Left","Right"]
   type: branch
   description: Wheel signals for axle
 

--- a/spec/default_instances.vspec
+++ b/spec/default_instances.vspec
@@ -1,0 +1,33 @@
+# Copyright (c) 2026 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
+# The default instance file shall reflect typical setup for a "normal" passenger car
+# The instance pattern in this file is non-normative, but shall be seen as a recommendation
+
+# Instance recommendations
+
+# If using Row[x,y]
+
+
+
+Vehicle.Chassis.Axle:
+  type: branch
+  instances:
+    - Row[1,2]
+
+
+Vehicle.Chassis.Axle.Wheel:
+  type: branch
+  instances: ["Left","Right"]
+
+
+Vehicle.Cabin.Seat:
+  type: branch
+  instances:
+    - Row[1,2]
+    - ["DriverSide","Middle","PassengerSide"]


### PR DESCRIPTION
This is a PR for discussion. Now and then we have discussed how to handle instances as they typically varies. This ticket concerns an idea of decoupling instance definition from the actual tree. In shot - anyone can use what instances they find useful for their vehicle. But for reference VSS can publish a default instance set to get same signals as today.

`vspec export yaml -u ./spec/units.yaml --strict -s ./spec/VehicleSignalSpecification.vspec -o vss.yaml -l spec/default_instances.vspec`

- Advantage - Makes it easier to customize as needed
- Disadvantage - risk that there will be no "common" model on where/how  to define instances.

The latter could possibly be handled by both documenting recommended instantiation models ("use RowX  for axles") or alternatively by adding syntax support to define "allowed" instance models for signals, like `instance_type: ROW_POS`. We could also just give recommendations in the `default_instances.vspec`

If we go this way we need to agree on what our standard release assets shall contain - with/without default instances.

Related to #898 #810 #642 #564