### PR TITLE
feat: add schemas/vspec-node.schema.json — machine-readable vspec node format

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ You can find current call coordinates and dates in [our wiki](https://github.com
 
 For detailed information see our [contribution guide](CONTRIBUTING.md)!
 
+### Machine-readable node schema
+
+`schemas/vspec-node.schema.json` is a [JSON Schema 2020-12](https://json-schema.org/draft/2020-12/schema) document that describes every field a vspec YAML node may carry. Third-party tooling authors can validate against it so that unknown or misspelled fields are caught at parse time, and any future field additions to the spec are automatically a visible, reviewable diff to the schema. The `additionalProperties: false` constraint is intentional — it makes the schema normative rather than just descriptive.
+
 ### VSS version and release handling
 
 Both VSS (this repository) and [VSS-tools](https://github.com/COVESA/vss-tools) use a [PEP](https://peps.python.org/pep-0440/)

--- a/schemas/vspec-node.schema.json
+++ b/schemas/vspec-node.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://covesa.github.io/vehicle_signal_specification/schemas/vspec-node.schema.json",
+  "title": "VSS vspec node",
+  "description": "A single node in a VSS vspec YAML file.",
+  "type": "object",
+  "required": ["type"],
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": ["branch", "sensor", "actuator", "attribute"],
+      "description": "Node kind. branch = non-leaf container; sensor/actuator/attribute = leaf."
+    },
+    "datatype": {
+      "type": "string",
+      "description": "Value type for leaf nodes, e.g. float, uint8, string, boolean. Required for sensor/actuator/attribute; not used on branch."
+    },
+    "description": {
+      "type": "string",
+      "description": "Human-readable description of the signal or branch."
+    },
+    "unit": {
+      "type": "string",
+      "description": "Unit of measure. Should be a value from the VSS unit catalogue (spec/units.yaml)."
+    },
+    "min": {
+      "description": "Minimum valid value (numeric). Applies to leaf nodes only."
+    },
+    "max": {
+      "description": "Maximum valid value (numeric). Applies to leaf nodes only."
+    },
+    "default": {
+      "description": "Default value for the signal at startup. Type must match datatype."
+    },
+    "comment": {
+      "type": "string",
+      "description": "Informative note, not part of the normative definition."
+    },
+    "deprecation": {
+      "type": "string",
+      "description": "Non-empty string indicates this node is deprecated; value is the deprecation notice including the version when it was deprecated."
+    },
+    "instances": {
+      "description": "Instance expansion expression (string or array of strings) for parameterised branches.",
+      "oneOf": [
+        { "type": "string" },
+        { "type": "array", "items": { "type": "string" }, "minItems": 1 }
+      ]
+    },
+    "allowed": {
+      "type": "array",
+      "description": "Enumerated allowed values for the signal. Items should match the datatype.",
+      "minItems": 1
+    },
+    "pattern": {
+      "type": "string",
+      "description": "Regular expression that the signal value must match."
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary

- Adds `schemas/vspec-node.schema.json` — a [JSON Schema 2020-12](https://json-schema.org/draft/2020-12/schema) document describing every field a vspec YAML node may carry.
- Updates `README.md` with a one-paragraph note pointing to the schema.

## Motivation

The vspec YAML node format is currently documented only by example and by the Python toolchain's parser. Third-party tooling authors must reverse-engineer the field set and silently drop unknown fields when the spec adds new ones. A JSON Schema document gives them a stable, versioned contract to validate against.

The `additionalProperties: false` constraint is the key part — it makes the schema **normative** rather than just descriptive. Any field added to the spec in the future without updating the schema becomes a visible, reviewable diff rather than a silent addition.

## Schema coverage

| Field | Type | Notes |
|---|---|---|
| `type` | enum | `branch`, `sensor`, `actuator`, `attribute` (required) |
| `datatype` | string | required for leaf nodes |
| `description` | string | |
| `unit` | string | should match `spec/units.yaml` |
| `min` / `max` | any | numeric range |
| `default` | any | type must match datatype |
| `comment` | string | informative only |
| `deprecation` | string | non-empty = deprecated |
| `instances` | string or string[] | instance expansion |
| `allowed` | array | enumerated allowed values |
| `pattern` | string | regex constraint on value |

## Test plan

- [ ] `jsonschema` validates each of the sample vspec files against this schema
- [ ] All fields actually used in `spec/` are represented
- [ ] `additionalProperties: false` catches unknown fields