### PR TITLE
feat(exterior): add RoadSurfaceTemperature sensor signal

### DIFF
--- a/spec/Safety/Safety.vspec
+++ b/spec/Safety/Safety.vspec
@@ -99,7 +99,7 @@ RoadIcingState:
     adequate winter-tire grip).
     May be derived from Vehicle.Exterior.RoadSurfaceCondition,
     Vehicle.Exterior.AirTemperature, Vehicle.ADAS.ESC.RoadFriction.MostProbable,
-    and road-surface-temperature signals.
+    and Vehicle.Exterior.RoadSurfaceTemperature.
     NONE indicates no elevated icing risk.
     RISK indicates conditions favor ice formation or onset of icing-related
     traction loss.

--- a/spec/Vehicle/Exterior.vspec
+++ b/spec/Vehicle/Exterior.vspec
@@ -53,6 +53,24 @@ RoadSurfaceCondition:
     Primary consumers: navigation and ADAS safety systems.
     Related to VSS issue #877 (Connected Safety signals).
 
+RoadSurfaceTemperature:
+  datatype: float
+  type: sensor
+  unit: Celsius
+  description: Temperature of the road surface beneath or ahead of the vehicle.
+  comment: >
+    Distinct from Vehicle.Exterior.AirTemperature: the road surface can sit
+    several degrees below the air, most notably on bridge decks and in shaded
+    cuttings, so surface temperature is the determining input for icing risk
+    when the air reads above freezing while the road is still frozen.
+    A natural fusion input to Vehicle.Exterior.RoadSurfaceCondition alongside
+    air temperature and Vehicle.ADAS.ESC.RoadFriction.MostProbable, and to
+    Vehicle.Safety.RoadIcingState where available.
+    Measurement method is implementation specific (typically infrared
+    pyrometer) and the value may also originate from external road-weather
+    infrastructure.
+    Related to VSS issue #877 (Connected Safety signals).
+
 RoadSurfaceContaminant:
   datatype: uint8
   type: sensor


### PR DESCRIPTION
Adds `Vehicle.Exterior.RoadSurfaceTemperature`, placed immediately after `RoadSurfaceCondition` — the signal it feeds.

Opened at @tguild's invitation ([tguild/vehicle_signal_specification#1](https://github.com/tguild/vehicle_signal_specification/pull/1)). The signal was prepared against his `feat/sensoris-road-conditions-visibility` branch, but did not travel with #918 when that branch merged, so it is not on master. This is that signal, rebased onto master, plus one wording correction described below.

### Signal

| Signal | Datatype | Unit | Type |
|--------|----------|------|------|
| `Vehicle.Exterior.RoadSurfaceTemperature` | `float` | `Celsius` | `sensor` |

### Why separate from `AirTemperature`

A road surface can sit several degrees below the air — most notably on bridge decks and in shaded cuttings. That gap is why surface temperature, not air temperature, is the determining input for icing risk: the air can read above freezing while the road is still frozen. It is a natural fusion input to `RoadSurfaceCondition` alongside air temperature and `Vehicle.ADAS.ESC.RoadFriction.MostProbable`, and to `Vehicle.Safety.RoadIcingState`.

SENSORIS v1.6 has no surface-temperature definition, so there is no proto enum to map — this is a plain `float`/`Celsius` sensor and sits outside the #873 enum/allowed-values discussion entirely. The quantity is already published by open road-weather infrastructure per station (e.g. Finnish Digitraffic `roadSurfaceTemperature`).

### Second change: a dangling reference of mine

`spec/Safety/Safety.vspec:102`, which I added in #906, currently reads:

> May be derived from Vehicle.Exterior.RoadSurfaceCondition, Vehicle.Exterior.AirTemperature, Vehicle.ADAS.ESC.RoadFriction.MostProbable, **and road-surface-temperature signals.**

That last clause points at a signal that is not in the spec. This PR repoints it at `Vehicle.Exterior.RoadSurfaceTemperature` by path. If you would rather take the signal alone and leave the comment to a separate PR, say so and I will split it.

### Verification

Build-verified against this branch before opening, using the repo's own toolchain:

```
vspec export json -u ./spec/units.yaml --strict -s ./spec/VehicleSignalSpecification.vspec
```

Exit 0. The exported JSON was then read, not just the exit code: `RoadSurfaceTemperature` is present as `datatype: float`, `unit: Celsius`, `type: sensor`, and the `Vehicle.Safety.RoadIcingState` comment resolves to the real signal path (the previously dangling clause is gone). Test coverage for this change is the strict-mode export itself — the spec's validation path — since the change is a signal definition plus a comment, with no code path of its own.

Placement and wording are yours to curate — happy to adjust.
