### PR TITLE
Add air quality signals for cabin and exterior air

### DIFF
--- a/spec/Cabin/Cabin.vspec
+++ b/spec/Cabin/Cabin.vspec
@@ -30,6 +30,14 @@ HVAC:
 #include HVAC.vspec HVAC
 
 ##
+# Air quality signals
+##
+AirQuality:
+  type: branch
+  description: Signals describing the composition of the air inside the vehicle cabin.
+#include ../include/AirComposition.vspec AirQuality
+
+##
 # Infotainment
 ##
 Infotainment:

--- a/spec/Vehicle/Exterior.vspec
+++ b/spec/Vehicle/Exterior.vspec
@@ -223,3 +223,8 @@ WindDirection:
     (0 = from North, 90 = from East, 180 = from South, 270 = from West).
     Only meaningful when WindSpeed is above a minimum threshold; value when
     WindSpeed is near 0 is implementation specific.
+
+AirQuality:
+  type: branch
+  description: Signals describing the composition of the ambient air outside the vehicle.
+#include ../include/AirComposition.vspec AirQuality

--- a/spec/include/AirComposition.vspec
+++ b/spec/include/AirComposition.vspec
@@ -1,0 +1,76 @@
+# Copyright (c) 2026 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
+#
+# Air composition (air quality) signals.
+#
+# This file is intended to be included with a branch prefix so that the same
+# set of measurements can be reported for cabin (interior) air and for
+# ambient (exterior) air, e.g.:
+#
+#   #include ../include/AirComposition.vspec AirQuality
+#
+# All signals are concentrations of pollutants relevant to occupant health
+# and to HVAC automation (recirculation control, cabin filter monitoring,
+# air purifier control).
+#
+
+PM1:
+  datatype: float
+  type: sensor
+  unit: ug/m^3
+  min: 0
+  description: Mass concentration of particulate matter with aerodynamic diameter
+               of 1 micrometer or less (PM1.0).
+
+PM25:
+  datatype: float
+  type: sensor
+  unit: ug/m^3
+  min: 0
+  description: Mass concentration of particulate matter with aerodynamic diameter
+               of 2.5 micrometers or less (PM2.5).
+
+PM10:
+  datatype: float
+  type: sensor
+  unit: ug/m^3
+  min: 0
+  description: Mass concentration of particulate matter with aerodynamic diameter
+               of 10 micrometers or less (PM10).
+
+CO2:
+  datatype: float
+  type: sensor
+  unit: ppm
+  min: 0
+  description: Carbon dioxide (CO2) concentration.
+  comment: If the sensor reports an estimated CO2 level (eCO2/CO2eq) derived from
+           other gas measurements rather than a direct CO2 measurement, the
+           estimated value may be reported here.
+
+NO2:
+  datatype: float
+  type: sensor
+  unit: ppb
+  min: 0
+  description: Nitrogen dioxide (NO2) concentration.
+
+Ozone:
+  datatype: float
+  type: sensor
+  unit: ppb
+  min: 0
+  description: Ozone (O3) concentration.
+
+TVOC:
+  datatype: float
+  type: sensor
+  unit: ppb
+  min: 0
+  description: Total volatile organic compounds (TVOC) concentration.

--- a/spec/quantities.yaml
+++ b/spec/quantities.yaml
@@ -84,3 +84,6 @@ illuminance:
 precipitation-rate:
   definition: Depth of precipitation accumulated per unit time (ISO 80000-3:2019 applied to meteorology)
   remark: Typically measured in millimeters per hour (mm/h). Applies to rain, snow (liquid equivalent), and mixed precipitation.
+mass-per-volume:
+  definition: Mass of a constituent divided by the volume of the mixture (ISO 80000-9:2019)
+  remark: Used for mass concentration of pollutants in air, e.g. particulate matter in micrograms per cubic meter.

--- a/spec/units.yaml
+++ b/spec/units.yaml
@@ -628,3 +628,30 @@ lx:
   qudt:
     unit: http://qudt.org/vocab/unit/LUX
     quantity-kind: https://qudt.org/vocab/quantitykind/LuminousFluxPerArea
+
+# Concentration
+
+ppm:
+  definition: Concentration measured in parts per million
+  unit: parts per million
+  quantity: relation
+  allowed-datatypes: ['numeric']
+  qudt:
+    unit: http://qudt.org/vocab/unit/PPM
+    quantity-kind: https://qudt.org/vocab/quantitykind/DimensionlessRatio
+ppb:
+  definition: Concentration measured in parts per billion
+  unit: parts per billion
+  quantity: relation
+  allowed-datatypes: ['numeric']
+  qudt:
+    unit: http://qudt.org/vocab/unit/PPB
+    quantity-kind: https://qudt.org/vocab/quantitykind/DimensionlessRatio
+ug/m^3:
+  definition: Mass concentration measured in micrograms per cubic meter
+  unit: microgram per cubic meter
+  quantity: mass-per-volume
+  allowed-datatypes: ['numeric']
+  qudt:
+    unit: http://qudt.org/vocab/unit/MicroGM-PER-M3
+    quantity-kind: https://qudt.org/vocab/quantitykind/MassDensity


### PR DESCRIPTION
Closes #930

Adds seven air quality measurements to both the cabin and the exterior, plus the concentration units the catalog is missing.

```
Vehicle.Cabin.AirQuality.{PM1, PM25, PM10, CO2, NO2, Ozone, TVOC}
Vehicle.Exterior.AirQuality.{PM1, PM25, PM10, CO2, NO2, Ozone, TVOC}
units:      ppm, ppb, ug/m^3        quantities: mass-per-volume
```

All `type: sensor`, `datatype: float`, `min: 0`, no max. Defined once in `spec/include/AirComposition.vspec` and included from both branches with a prefix, the same way `SingleHVACStation.vspec` and `include/MovableItem.vspec` are reused today, so the two branches cannot drift apart.

**Validation.** `vspec export json --strict` passes on the patched tree using vss-tools installed from git master, which is what CI uses. Leaf count goes from 1367 to 1381, which is the 14 new signals and nothing else. Released vss-tools 6.0.0 from PyPI fails on unmodified master for unrelated reasons, so master is the version to test with.

**Some decisions worth flagging, since I expect discussion on them:**

`PM25` rather than `PM2.5` or `PM2_5`, because no signal name in the catalog currently contains a dot or an underscore. The description spells out the 2.5 micrometer cutoff.

Not under `Cabin.HVAC`, because HVAC in VSS models the climate actuation system. Air composition is a property of the cabin that exists whether or not HVAC acts on it.

New units are the widest part of this change. `ppm` and `ppb` go under the existing `relation` quantity alongside `percent`. `ug/m^3` needs a new `mass-per-volume` quantity, named after the existing `mass-per-time` and `mass-per-distance`. QUDT references included, all resolvable.

No AQI. Air quality indices are jurisdiction specific and derivable from the raw values, so they seemed like the wrong thing to standardize.

CO2 is the one I am least sure about. Many low cost parts report estimated eCO2 derived from a VOC channel rather than true NDIR CO2, and the two behave differently, so the signal carries a comment saying so. If reviewers would rather split it into `CO2` and `CO2Estimated`, that seems reasonable to me.

TVOC is in ppb, which is what sensors emit, though the reference methods report total VOC as a mass concentration. If the standards aligned unit is preferred, switching it to `ug/m^3` is a one line change since that unit is already in this PR.

The exterior branch is the weaker half of this proposal and I would rather say so than have it found. Exterior CO2 in particular sits near 420 ppm everywhere and has no obvious use. It is there because the shared include keeps the branches identical by construction. If you would rather trim exterior to the signals with a real use case, that is a small change and I have no objection.

**Where this came from.** I was bringing an air quality sensor into QNX and wanted to publish it as VSS signals on the QNX signal service, which is COVESA VSS based. There was nothing to publish to. The implementation runs on real hardware and is public, if it is useful context: https://github.com/ethanrossauto/qnx-air-quality-sensor
