### PR TITLE
Adding PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,47 @@
+<!--
+Contributions to COVESA must follow the COVESA Antitrust and Open Statements
+available on the link below and for convenience copied below
+
+https://covesa.atlassian.net/wiki/x/FhxUAg
+
+
+Contributing to COVESA Activities
+
+Companies and individuals contributing to COVESA activities should understand the COVESA IP Policy and know that all COVESA work products, including software and documents, will be released under an open source license as described in the Public Policy for Open Source Licensing. Contributors must also follow COVESA’s Export Controls and Sanctions Compliance Policy. Before a contribution can be accepted, contributors must provide their name, contributing organization if the contribution is not personal, email address, and country.
+
+COVESA is not a standards body. Any COVESA activity that requires a formal specification must first be approved by the Board of Directors and then moved to a formal standards development organization.
+
+Please do not contribute ideas or code that may involve patents unless you disclose to other participants, through meeting minutes or pull requests, that use of the contribution could potentially infringe a patent
+
+-->
+
+## Description
+
+<!-- Please describe what this Pull Request contain -->
+
+## Contributor Information
+
+<!-- Please fill in the fields below
+
+Name(s): Shall be name as written in passport
+Organization: Full name of the organization that contributes this.
+              This shall be the organization (if any) that has copyright to the code.
+              Write "N/A" if it is a personal contribution
+E-mail: A valid e-mail address. To avoid spam masking is allowed. A few allowed examples below
+
+john.doe@example.com
+john dot doe at example dot com
+john.d*e@example.c*m, *=o
+
+Country: Country/Countries in which the contribution has been developed,
+         i.e. physical location of contributor(s).
+         Country of residence, citizenship, or location of contributor organization shall not be considered.
+
+Example: If you are a Norwegian citizen living in Sweden and contributing code on behalf of a company located in Finland, and the code has been created while on vacation to denamrk, then you shall state Denmark!
+
+-->
+
+* Contributor name(s):
+* Contributing Organization:
+* E-mail:
+* Country:


### PR DESCRIPTION
This a proposal on how to handle the new COVESA contributor agreement. With a PR template you will see something like this when creating a PR

<img width="1444" height="818" alt="image" src="https://github.com/user-attachments/assets/4b444129-7195-416b-80b3-ca24d44f8174" />

And in rendered view this corresponds to:

<img width="933" height="528" alt="image" src="https://github.com/user-attachments/assets/03780306-5c94-4f90-949b-44ea69b9ab9d" />

There are quite a lot of details where I do not know if we need to clarify corner cases. Like I contribute on behalf of a German company but I am located and employed in Sweden. I also assume that we do not want to request e-mail address in cleartext as that might lead to spams.

And if you do not like it this way we need to come up with an alternative way. Like if we do not want to have this info public we may request everyone to send a mail to Paul with the data. To be discussed in coming meetings

- And my assumption is that git commit signoff no longer is required, or? Well we still mention it at https://covesa.global/about-covesa/#contribute-code

```
For legal compliance, every contribution must carry the following information:

a) sign-off line with your real name and email (i.e., Signed-off-by: Firstname Lastname you@example.com)
b) entity name if contributing on its behalf (otherwise, it will be considered an individual contribution)
c) country from which contribution originates.
```

So do we want this info on every commit or every PR? every commit is safer if we cherry pick commits, but also more complex to use. So is PR sufficient?


## Contributor Information

* Contributor name(s): Erik Jaegervall
* Contributing Organization: Robert Bosch GmbH
* E-mail: erik dot jaegervall at bosch dot com
* Country: Sweden
