### PR TITLE
VehicleIdentification: WMI definition, AcrissCode pattern, BodyType citation

### DIFF
--- a/spec/Body/Body.vspec
+++ b/spec/Body/Body.vspec
@@ -13,7 +13,8 @@
 BodyType:
   datatype: string
   type: attribute
-  description: Body type code as defined by ISO 3779.
+  description: Body type code of the vehicle, from the type-approval or registration scheme it is subject to.
+  comment: ISO 3779 defines the VIN and no body type codes. VehicleIdentification.BodyType is the descriptive form.
 
 #
 # Hood description

--- a/spec/Vehicle/Vehicle.vspec
+++ b/spec/Vehicle/Vehicle.vspec
@@ -60,7 +60,9 @@ VehicleIdentification.VIN:
 VehicleIdentification.WMI:
   datatype: string
   type: attribute
-  description: 3-character World Manufacturer Identification (WMI) as defined by ISO 3780.
+  description: World Manufacturer Identifier (WMI) as defined by ISO 3780, three characters,
+               or six characters for a low-volume manufacturer (VIN positions 1-3 and 12-14).
+  pattern: ^[0-9A-HJ-NPR-Z]{3}(?:[0-9A-HJ-NPR-Z]{3})?$
 
 VehicleIdentification.Brand:
   datatype: string

--- a/spec/Vehicle/Vehicle.vspec
+++ b/spec/Vehicle/Vehicle.vspec
@@ -91,6 +91,7 @@ VehicleIdentification.AcrissCode:
   datatype: string
   type: attribute
   description: The ACRISS Car Classification Code is a code used by many car rental companies.
+  pattern: ^[A-Z]{4}$
 
 VehicleIdentification.BodyType:
   datatype: string


### PR DESCRIPTION
## What changed

Two files, three commits, one attribute each. Non-breaking.

1. **`VehicleIdentification.WMI`**. Description said "3-character". A WMI is three characters, or six for a low-volume manufacturer (third character 9, completed by VIN positions 12-14, ISO 3780). Description corrected; `pattern: ^[0-9A-HJ-NPR-Z]{3}(?:[0-9A-HJ-NPR-Z]{3})?$` accepts both forms. "Identification" becomes "Identifier", the ISO 3780 term.
2. **`VehicleIdentification.AcrissCode`**. `pattern: ^[A-Z]{4}$`. An ACRISS code is four upper-case letters.
3. **`Vehicle.Body.BodyType`**. Description said "as defined by ISO 3779". ISO 3779 defines the VIN and no body type codes. Description now states where codes come from; one-line comment separates it from the descriptive `VehicleIdentification.BodyType`.

## Why

The WMI text excluded more than a quarter of registered manufacturers. AcrissCode had a defined format and no constraint. BodyType carried a citation that does not hold.

## What we measured

Measured against Cardog's decoded unit corpus: 1,870,496 distinct VINs from Canadian and US registration, dealer and insurer feeds, decoded with vPIC-derived schemas, counted 2026-09-09. Percentages are of that total unless a row says otherwise. Counts are exact.

| Question | Population | Result |
|---|---|---|
| How many registered WMIs are six characters? | NHTSA vPIC WMI registry, 41,708 WMIs | 11,286 (27.1%), every one with 9 in position 3; none of the 30,422 three-character WMIs has a 9 there |
| Does the existing VIN pattern (6.0, #786) hold? | 1,870,496 units | 1,868,505 match (99.89%); all 1,991 misses have non-digits in positions 14-17 and trace to non-VIN source data (masked values, dealer stock numbers) |
| Same question, a registry population | New York State registrations, 4,525,000 rows | 4,452,886 match (98.4%); 71,669 (1.58%) are not 17 characters; 1,688 contain I, O or Q |
| Could the pattern require the last five numeric? | 1,870,496 units | No. 894 units carry a letter in position 13, all trailer, RV and heavy-truck WMIs. 49 CFR 565.15(d) requires five only for light vehicles under 4,536 kg. |

## Prior art

- ISO 3779 (VIN structure), ISO 3780 (WMI, low-volume rule).
- #786 added the VIN `pattern` in 6.0. This PR leaves it unchanged.
- ACRISS Car Classification Code, acriss.org: four characters, category / type / transmission and drive / fuel and air conditioning.

## Review request

1. One WMI attribute for both forms (as vPIC and decoders store it), or a separate attribute for the low-volume extension?
2. Does the BodyType description change belong here, or with a 7.0 discussion on merging the two BodyType nodes?

## Contributor information

- Contributor name: Sam Sullivan-Del Gobbo
- Contributing organization: Cardog Inc.
- E-mail: sam at cardog dot io
- Country where the change was written: Canada
